### PR TITLE
Add and allow slippage adjustment for trades

### DIFF
--- a/components/swap/SwapInputView.tsx
+++ b/components/swap/SwapInputView.tsx
@@ -36,6 +36,7 @@ interface SwapInputViewProps {
   isLoadingCurrentToTokenBalance: boolean;
   calculatedValues: {
     fees: FeeDetail[];
+    slippage: string;
   };
   dynamicFeeLoading: boolean;
   quoteLoading: boolean;
@@ -47,6 +48,8 @@ interface SwapInputViewProps {
   currentChainId: number | undefined;
   TARGET_CHAIN_ID: number;
   strokeWidth?: number;
+  slippage: string; // percentage value without % sign e.g., "5"
+  handleSlippageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export function SwapInputView({
@@ -81,6 +84,8 @@ export function SwapInputView({
   currentChainId,
   TARGET_CHAIN_ID,
   strokeWidth = 2,
+  slippage,
+  handleSlippageChange,
 }: SwapInputViewProps) {
   return (
     <motion.div key="input" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0, y: -20 }} transition={{ duration: 0.2 }}>
@@ -254,6 +259,23 @@ export function SwapInputView({
               )}
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Slippage Input */}
+      {isConnected && (
+        <div className="flex items-center justify-between mt-3">
+          <span className="text-xs text-muted-foreground">Slippage (%)</span>
+          <Input
+            type="number"
+            min="0"
+            max="100"
+            step="0.1"
+            value={slippage}
+            onChange={handleSlippageChange}
+            className="w-20 h-7 text-xs text-right"
+            disabled={isAttemptingSwitch}
+          />
         </div>
       )}
 

--- a/components/swap/swap-interface.tsx
+++ b/components/swap/swap-interface.tsx
@@ -1294,7 +1294,17 @@ export function SwapInterface() {
                  toTokenSymbol: toToken.symbol === 'YUSDC' ? 'YUSDC' : 'BTCRL', // Always use valid TOKEN_DEFINITIONS keys
                  swapType: 'ExactIn', // Assuming ExactIn, adjust if dynamic
                  amountDecimalsStr: fromAmount, // The actual amount user wants to swap
-                 limitAmountDecimalsStr: "0", // Placeholder for min received, API might calculate or take this
+                 limitAmountDecimalsStr: (() => {
+                      const quoteOut = parseFloat(toAmount || "0");
+                      if (quoteOut === 0 || isNaN(quoteOut)) return "0";
+                      const slippageFloat = parseFloat(slippagePct);
+                      const tolerance = isNaN(slippageFloat) ? 5 : slippageFloat; // fallback default
+                      const minOut = quoteOut * (1 - tolerance / 100);
+                      const decimals = toToken.decimals;
+                      // Ensure proper decimal precision
+                      const fixed = decimals === 0 ? Math.floor(minOut).toString() : minOut.toFixed(decimals);
+                      return fixed;
+                 })(),
                  
                  permitSignature: signatureToUse || "0x", 
                  permitTokenAddress: fromToken.address, // Token that was permitted (fromToken)

--- a/components/swap/swap-interface.tsx
+++ b/components/swap/swap-interface.tsx
@@ -351,6 +351,9 @@ export function SwapInterface() {
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null); // This will be removed
   const intervalTimerRef = useRef<NodeJS.Timeout | null>(null);
 
+  // --- Slippage State ---
+  const [slippagePct, setSlippagePct] = useState<string>("5"); // default 5%
+
   // Add necessary hooks for swap execution
   const { signTypedDataAsync } = useSignTypedData();
   const { data: swapTxHash, writeContractAsync: sendSwapTx, isPending: isSwapTxPending, error: swapTxError } = useWriteContract();
@@ -377,7 +380,7 @@ export function SwapInterface() {
     fees: [
       { name: "Fee", value: "N/A", type: "percentage" }, // Initial value updated
     ],
-    slippage: "0.5%",
+    slippage: "5%",
   });
 
   // Mock data generation removed - using real API data instead
@@ -825,10 +828,10 @@ export function SwapInterface() {
       toTokenAmount: formatTokenAmountDisplay(toAmount, toToken.symbol),
       toTokenValue: formatCurrency(newToTokenValue.toString()),
       fees: updatedFeesArray, 
-      slippage: prev.slippage, 
+      slippage: `${slippagePct}%`,
     }));
 
-  }, [fromAmount, toAmount, fromToken, toToken, formatCurrency, isConnected, currentChainId, dynamicFeeLoading, dynamicFeeError, dynamicFeeBps, formatTokenAmountDisplay]); // Added formatTokenAmountDisplay dependency
+  }, [fromAmount, toAmount, fromToken, toToken, formatCurrency, isConnected, currentChainId, dynamicFeeLoading, dynamicFeeError, dynamicFeeBps, formatTokenAmountDisplay, slippagePct]); // Added formatTokenAmountDisplay dependency
 
   const handleFromAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -1301,6 +1304,7 @@ export function SwapInterface() {
                  permitSigDeadline: permitDetailsToUse.sigDeadline ? permitDetailsToUse.sigDeadline.toString() : effectiveFallbackSigDeadline.toString(),
                  chainId: currentChainId,
                  dynamicSwapFee: fetchedDynamicFee, // <<< PASS THE FETCHED FEE
+                 slippagePercent: parseFloat(slippagePct),
             };
 
             // --- Call Build TX API ---
@@ -1808,6 +1812,8 @@ export function SwapInterface() {
                 currentChainId={currentChainId}
                 TARGET_CHAIN_ID={TARGET_CHAIN_ID}
                 strokeWidth={2}
+                slippage={slippagePct}
+                handleSlippageChange={(e) => setSlippagePct(e.target.value)}
               />
             )}
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a preset 5% slippage to all trades and allow users to adjust it in the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e7f0da7-4b1e-4015-9d98-35dcc0c3aef1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e7f0da7-4b1e-4015-9d98-35dcc0c3aef1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>