### PR TITLE
Redis caching for liquidity page

### DIFF
--- a/app/api/liquidity/chart-data/[poolId]/route.ts
+++ b/app/api/liquidity/chart-data/[poolId]/route.ts
@@ -38,14 +38,21 @@ const GET_POOL_DAILY_HISTORY_QUERY = `
   }
 `;
 
+import { getPoolSubgraphId } from '../../../../../lib/pools-config';
+
 // Helper to map friendly pool IDs to actual subgraph IDs
 const getSubgraphPoolId = (friendlyPoolId: string): string => {
+  const subgraphId = getPoolSubgraphId(friendlyPoolId);
+  if (subgraphId) {
+    return subgraphId.toLowerCase(); // Ensure lowercase for subgraph
+  }
+  
+  // Fallback for legacy handling
   if (friendlyPoolId.toLowerCase() === 'yusdc-btcrl') {
     return "0xbcc20db9b797e211e508500469e553111c6fa8d80f7896e6db60167bcf18ce13";
   }
-  // Add other mappings as needed
-  // If no mapping, assume the friendlyPoolId is already the correct subgraph ID (e.g., if it's a hex string)
-  // Ensure it's lowercase if your subgraph expects Bytes! as lowercase hex
+  
+  // If no mapping found, assume it's already a hex ID
   return friendlyPoolId.toLowerCase(); 
 };
 

--- a/app/api/liquidity/get-pools-batch/route.ts
+++ b/app/api/liquidity/get-pools-batch/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPoolById, getToken } from '@/lib/pools-config'
+import { publicClient } from '@/lib/viemClient'
+import { parseAbi, getAddress, type Hex } from 'viem'
+import { STATE_VIEW_ABI } from '@/lib/abis/state_view_abi'
+import { withCache } from '@/lib/redis'
+import { cacheKeys, cacheTTL } from '@/lib/cache-keys'
+
+const SUBGRAPH_URL = "https://api.studio.thegraph.com/query/111443/alphix-v-4/version/latest"
+const STATE_VIEW_ADDRESS = getAddress("0x571291b572ed32ce6751a2cb2486ebee8defb9b4")
+
+// Types
+interface PoolStats {
+  poolId: string
+  tvlUSD: number
+  volume24hUSD: number
+  fees24hUSD: number
+  dynamicFeeBps: number
+}
+
+interface PoolConfig {
+  id: string
+  subgraphId: string
+  currency0: { symbol: string }
+  currency1: { symbol: string }
+}
+
+// Utility functions
+function parseTokenAmount(val: unknown, decimals: number): number {
+  if (val === null || val === undefined) return 0
+  const num = typeof val === 'string' ? parseFloat(val) : Number(val)
+  return isNaN(num) ? 0 : num
+}
+
+function extractDynamicFeeBps(slot0: readonly [bigint, number, number, number]): number {
+  // slot0[3] is the dynamic fee in basis points
+  return Number(slot0[3]) || 0
+}
+
+// Build GraphQL query dynamically based on pool count
+function buildQuery(poolCount: number) {
+  return `
+    query GetPoolsBatch($poolIds: [String!]!, $cutoffHours: Int!) {
+      pools(where: { id_in: $poolIds }) {
+        id
+        totalValueLockedToken0
+        totalValueLockedToken1
+      }
+      poolHourDatas(
+        first: ${poolCount * 25}
+        where: { pool_in: $poolIds, periodStartUnix_gte: $cutoffHours }
+        orderBy: periodStartUnix
+        orderDirection: desc
+      ) {
+        pool { id }
+        volumeToken0
+        feesToken0
+      }
+    }
+  `
+}
+
+// Core fetcher - extracted for caching
+async function fetchPoolsBatchData(poolIds: string[]): Promise<PoolStats[]> {
+  // Map pool IDs to their subgraph IDs and configs
+  const poolMap = new Map<string, PoolConfig>()
+  const subgraphIds: string[] = []
+
+  for (const poolId of poolIds) {
+    const config = getPoolById(poolId)
+    if (config) {
+      const subgraphId = (config.subgraphId || poolId).toLowerCase()
+      poolMap.set(subgraphId, config as PoolConfig)
+      subgraphIds.push(subgraphId)
+    }
+  }
+
+  // Fetch on-chain data (slot0 for dynamic fees)
+  const stateViewAbi = parseAbi(STATE_VIEW_ABI)
+  const slot0Results = await Promise.allSettled(
+    Array.from(poolMap.entries()).map(async ([subgraphId]) => {
+      try {
+        const slot0 = await publicClient.readContract({
+          address: STATE_VIEW_ADDRESS,
+          abi: stateViewAbi,
+          functionName: 'getSlot0',
+          args: [subgraphId as Hex]
+        }) as readonly [bigint, number, number, number]
+        return { subgraphId, slot0 }
+      } catch {
+        return { subgraphId, slot0: null }
+      }
+    })
+  )
+
+  // Build fee map
+  const feeMap = new Map<string, number>()
+  for (const result of slot0Results) {
+    if (result.status === 'fulfilled' && result.value.slot0) {
+      feeMap.set(result.value.subgraphId, extractDynamicFeeBps(result.value.slot0))
+    }
+  }
+
+  // Fetch subgraph data
+  const cutoffHours = Math.floor(Date.now() / 1000) - (24 * 60 * 60)
+  const query = buildQuery(poolIds.length)
+
+  const subgraphRes = await fetch(SUBGRAPH_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query,
+      variables: { poolIds: subgraphIds, cutoffHours }
+    })
+  })
+
+  if (!subgraphRes.ok) {
+    throw new Error(`Subgraph error: ${subgraphRes.status}`)
+  }
+
+  const subgraphData = await subgraphRes.json()
+  const pools = subgraphData.data?.pools || []
+  const hourDatas = subgraphData.data?.poolHourDatas || []
+
+  // Build TVL map from pools
+  const tvlMap = new Map<string, { token0: number; token1: number }>()
+  for (const pool of pools) {
+    const id = pool.id.toLowerCase()
+    tvlMap.set(id, {
+      token0: parseTokenAmount(pool.totalValueLockedToken0, 18),
+      token1: parseTokenAmount(pool.totalValueLockedToken1, 18)
+    })
+  }
+
+  // Aggregate hourly data into 24h volume and fees
+  const volumeMap = new Map<string, { volume: number; fees: number }>()
+  for (const hd of hourDatas) {
+    const id = hd.pool.id.toLowerCase()
+    const existing = volumeMap.get(id) || { volume: 0, fees: 0 }
+    existing.volume += parseTokenAmount(hd.volumeToken0, 18)
+    existing.fees += parseTokenAmount(hd.feesToken0, 18)
+    volumeMap.set(id, existing)
+  }
+
+  // Assemble results
+  const results: PoolStats[] = []
+  for (const [subgraphId, config] of poolMap.entries()) {
+    const tvl = tvlMap.get(subgraphId)
+    const volume = volumeMap.get(subgraphId)
+
+    // Get token prices (simplified - using 1.0 for now, real implementation would fetch prices)
+    const price0 = 1.0 // TODO: Fetch real prices
+    const price1 = 1.0
+
+    const tvlUSD = tvl
+      ? (tvl.token0 * price0) + (tvl.token1 * price1)
+      : 0
+
+    results.push({
+      poolId: config.id,
+      tvlUSD,
+      volume24hUSD: volume?.volume ?? 0,
+      fees24hUSD: volume?.fees ?? 0,
+      dynamicFeeBps: feeMap.get(subgraphId) ?? 0
+    })
+  }
+
+  return results
+}
+
+// Validation: at least one pool should have non-zero TVL
+function validatePoolsData(data: PoolStats[]): boolean {
+  return data.length === 0 || data.some(p => p.tvlUSD > 0)
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { poolIds } = body as { poolIds: string[] }
+
+    if (!poolIds || !Array.isArray(poolIds) || poolIds.length === 0) {
+      return NextResponse.json({ error: 'poolIds array required' }, { status: 400 })
+    }
+
+    const results = await withCache(
+      cacheKeys.poolsBatch(),
+      () => fetchPoolsBatchData(poolIds),
+      {
+        freshTTL: cacheTTL.poolsBatch.fresh,
+        maxTTL: cacheTTL.poolsBatch.max,
+        validate: validatePoolsData
+      }
+    )
+
+    return NextResponse.json(results, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60'
+      }
+    })
+  } catch (error) {
+    console.error('[get-pools-batch] Error:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch pool data' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/liquidity/page.tsx
+++ b/app/liquidity/page.tsx
@@ -1,848 +1,205 @@
 "use client";
 
-import { AppLayout } from "@/components/app-layout";
-import { useState, useEffect, useMemo, useCallback } from "react";
-import { ArrowRightLeftIcon, PlusIcon, MinusIcon, ArrowLeftIcon, MoreHorizontal, ArrowUpDown, ExternalLinkIcon, RefreshCwIcon, Settings2Icon, XIcon, TrendingUpIcon, ChevronUpIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { 
-  Dialog, 
-  DialogContent, 
-  DialogHeader, 
-  DialogDescription, 
-  DialogFooter,
-  DialogTrigger,
-  DialogClose
-} from "@/components/ui/dialog";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { TabsList, TabsTrigger, Tabs, TabsContent } from "@/components/ui/tabs";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
+import { useState, useMemo } from "react";
 import Image from "next/image";
-import * as React from "react";
-import { 
-  ColumnDef,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  SortingState,
-  useReactTable,
-  RowData
-} from "@tanstack/react-table";
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import { useRouter } from "next/navigation";
+import { useAccount } from "wagmi";
+import { ColumnDef, flexRender, getCoreRowModel, getSortedRowModel, SortingState, useReactTable } from "@tanstack/react-table";
+import { AppLayout } from "@/components/app-layout";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { MobileLiquidityList } from "@/components/MobileLiquidityList";
-import { MobilePoolDetails } from "@/components/MobilePoolDetails";
-import type { ProcessedPosition } from "../../pages/api/liquidity/get-positions";
-import { 
-    useAccount, 
-    useWriteContract, 
-    useSendTransaction, 
-    useWaitForTransactionReceipt,
-    useBalance
-} from "wagmi";
-import { toast } from "sonner";
-import Link from "next/link";
-import { getAllPools, getEnabledPools, getToken, getPoolSubgraphId, TokenSymbol, TOKEN_DEFINITIONS } from "../../lib/pools-config";
-import { baseSepolia } from "../../lib/wagmiConfig";
-import { ethers } from "ethers";
-import { ERC20_ABI } from "../../lib/abis/erc20";
-import { type Hex, formatUnits as viemFormatUnits, parseUnits, type Abi } from "viem";
-import { position_manager_abi } from "../../lib/abis/PositionManager_abi";
-import { getFromCache, setToCache, getUserPositionsCacheKey, getPoolStatsCacheKey, getPoolDynamicFeeCacheKey } from "../../lib/client-cache"; // Import cache functions
-import { TickRangeControl } from "@/components/TickRangeControl";
-import { Pool } from "../../types"; // Import Pool interface from types
-import { AddLiquidityModal } from "@liquidity/AddLiquidityModal";
-import { useRouter } from "next/navigation";
-// import { DEFAULT_TICK_SPACING } from "@/components/TickRangeControl"; // Assuming DEFAULT_TICK_SPACING is exported or accessible
+import { getPoolsForDisplay } from "@/lib/pools-config";
+import { formatUSD } from "@/lib/format";
+import { usePoolsBatch, usePoolsAprBatch, useUserPositions } from "@/components/data/hooks";
+import type { Pool } from "@/types";
 
-const SDK_MIN_TICK = -887272;
-const SDK_MAX_TICK = 887272;
-const DEFAULT_TICK_SPACING = 60; // Define it locally
-const TICK_BARS_COUNT = 31; // More bars for finer visualization
-const TICKS_PER_BAR = 10 * DEFAULT_TICK_SPACING; // Each bar represents 10× tickspacing
+const basePools = getPoolsForDisplay();
 
-// Generate pools from pools.json configuration
-const generatePoolsFromConfig = (): Pool[] => {
-  const enabledPools = getEnabledPools();
-  
-  return enabledPools.map(poolConfig => {
-    const token0 = getToken(poolConfig.currency0.symbol);
-    const token1 = getToken(poolConfig.currency1.symbol);
-    
-    if (!token0 || !token1) {
-      console.warn(`Missing token configuration for pool ${poolConfig.id}`);
-      return null;
-    }
-    
-    return {
-      id: poolConfig.id,
-    tokens: [
-        { symbol: token0.symbol, icon: token0.icon },
-        { symbol: token1.symbol, icon: token1.icon }
-    ],
-      pair: `${token0.symbol} / ${token1.symbol}`,
-    volume24h: "Loading...",
-    volume7d: "Loading...",
-    fees24h: "Loading...",
-    fees7d: "Loading...",
-    liquidity: "Loading...",
-    apr: "Loading...",
-      highlighted: poolConfig.featured,
-    volumeChangeDirection: 'loading',
-    tvlChangeDirection: 'loading',
-    } as Pool;
-  }).filter(Boolean) as Pool[];
-};
-
-const dynamicPools = generatePoolsFromConfig();
-
-declare module '@tanstack/react-table' {
-  interface TableMeta<TData extends RowData> {
-    explorerBaseUrl?: string;
-  }
+// Reusable component for pool token pair icons
+function PoolTokenIcons({ tokens }: { tokens: Pool['tokens'] }) {
+  return (
+    <div className="relative w-14 h-7">
+      <div className="absolute top-0 left-0 w-7 h-7 rounded-full overflow-hidden bg-background border border-border/50">
+        <Image src={tokens[0].icon} alt={tokens[0].symbol} width={28} height={28} className="w-full h-full object-cover" />
+      </div>
+      <div className="absolute top-0 left-4 w-7 h-7 rounded-full overflow-hidden bg-background border border-border/50">
+        <Image src={tokens[1].icon} alt={tokens[1].symbol} width={28} height={28} className="w-full h-full object-cover" />
+      </div>
+    </div>
+  );
 }
 
-const chartData = Array.from({ length: 60 }, (_, i) => {
-  const date = new Date();
-  date.setDate(date.getDate() - i);
-  return {
-    date: date.toISOString().split('T')[0],
-    volume: Math.floor(Math.random() * 200000) + 100000,
-    tvl: Math.floor(Math.random() * 100000) + 1000000,
-  };
-}).reverse();
-
-const chartConfig = {
-  views: { label: "Daily Values" },
-  volume: { label: "Volume", color: "hsl(var(--chart-1))" },
-  tvl: { label: "TVL", color: "hsl(var(--chart-2))" },
-} satisfies ChartConfig;
-
-// Format USD value
-const formatUSD = (value: number) => {
-  if (value < 0.01) return "< $0.01";
-  if (value < 1000) return `$${value.toFixed(2)}`;
-  return `$${(value).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
-};
+// Helper to check if APR is loaded (not a placeholder)
+const isAprLoaded = (apr: string) => apr && !apr.includes("Loading");
 
 export default function LiquidityPage() {
-  const [isLoadingPositions, setIsLoadingPositions] = useState(false);
-  const [userPositions, setUserPositions] = useState<ProcessedPosition[]>([]); // Added state for all user positions
-  const [activeChart, setActiveChart] = React.useState<keyof typeof chartConfig>("volume");
-  const [sorting, setSorting] = React.useState<SortingState>([]);
-
-  const [poolsData, setPoolsData] = useState<Pool[]>(dynamicPools); // State for dynamic pool data
+  const [sorting, setSorting] = useState<SortingState>([]);
   const isMobile = useIsMobile();
-  const { address: accountAddress, isConnected, chain } = useAccount();
-  const [selectedPoolId, setSelectedPoolId] = useState<string>("");
-  const [windowWidth, setWindowWidth] = useState<number>(
-    typeof window !== 'undefined' ? window.innerWidth : 1200
-  );
-  const [addLiquidityOpen, setAddLiquidityOpen] = useState(false);
-  const [selectedPoolApr, setSelectedPoolApr] = useState<string | undefined>(undefined);
   const router = useRouter();
+  const { address } = useAccount();
 
-  // Add resize listener
-  useEffect(() => {
-    const handleResize = () => {
-      setWindowWidth(window.innerWidth);
-    };
+  const poolIds = useMemo(() => basePools.map(p => p.id), []);
+  const { data: batchData } = usePoolsBatch(poolIds);
+  const { data: aprData } = usePoolsAprBatch(poolIds);
+  const { data: positions = [], isLoading: loadingPositions } = useUserPositions(address);
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('resize', handleResize);
-      return () => {
-        window.removeEventListener('resize', handleResize);
-      };
-    }
-  }, []);
+  // Merge all data sources into enriched pools
+  const pools: Pool[] = useMemo(() => {
+    const batchMap = new Map(batchData?.map(p => [p.poolId.toLowerCase(), p]));
+    const aprMap = new Map(aprData?.map(p => [p.poolId.toLowerCase(), p]));
 
-  // Fetch all user positions
-  useEffect(() => {
-    if (isConnected && accountAddress) {
-      const cacheKey = getUserPositionsCacheKey(accountAddress);
-      const cachedPositions = getFromCache<ProcessedPosition[]>(cacheKey);
+    return basePools.map(pool => {
+      const batch = batchMap.get(pool.id.toLowerCase());
+      const apr = aprMap.get(pool.id.toLowerCase());
+      const [t0, t1] = pool.pair.split(' / ').map(s => s.trim().toUpperCase());
 
-      if (cachedPositions) {
-        console.log("[Cache HIT] Using cached user positions for", accountAddress);
-        setUserPositions(cachedPositions);
-        setIsLoadingPositions(false);
-        return;
-      }
-
-      console.log("[Cache MISS] Fetching user positions from API for", accountAddress);
-      setIsLoadingPositions(true);
-      fetch(`/api/liquidity/get-positions?ownerAddress=${accountAddress}`)
-        .then(res => {
-          if (!res.ok) { throw new Error(`Failed to fetch positions: ${res.statusText}`); }
-          return res.json();
-        })
-        .then((data: ProcessedPosition[] | { message: string }) => {
-          if (Array.isArray(data)) {
-            setUserPositions(data);
-            setToCache(cacheKey, data); // Cache the fetched positions
-            console.log("[Cache SET] Cached user positions for", accountAddress);
-          } else {
-            console.error("Error fetching positions on main page:", data.message);
-            toast.error("Could not load your positions for counts", { description: data.message });
-            setUserPositions([]);
-          }
-        })
-        .catch(error => {
-          console.error("Failed to fetch user positions for counts:", error);
-          toast.error("Failed to load your positions for counts.", { description: error.message });
-          setUserPositions([]);
-        })
-        .finally(() => {
-          setIsLoadingPositions(false);
-        });
-    } else {
-      setUserPositions([]); // Clear positions if not connected
-    }
-  }, [isConnected, accountAddress]);
-
-  // useEffect to fetch rolling volume and fees for each pool
-  useEffect(() => {
-    const fetchPoolStats = async (pool: Pool): Promise<Partial<Pool>> => {
-      const apiPoolId = getPoolSubgraphId(pool.id) || pool.id;
-      const statsCacheKey = getPoolStatsCacheKey(apiPoolId);
-      let cachedStats = getFromCache<Partial<Pool>>(statsCacheKey);
-
-      // If we have cached stats, we might still need to fetch/recalculate APR if it's not there or uses a separate fee cache
-      // For simplicity, if basic stats are cached, we'll try to use them and then fetch fee separately if needed for APR.
-
-      if (cachedStats && cachedStats.apr && cachedStats.volume24hUSD !== undefined && cachedStats.tvlUSD !== undefined) {
-        console.log(`[Cache HIT] Using fully cached stats (incl. APR) for pool: ${pool.pair}, API ID: ${apiPoolId}`);
-        return cachedStats; 
-      }
-      
-      console.log(`[Cache MISS or APR missing] Fetching/Recomputing stats for pool: ${pool.pair}, using API ID: ${apiPoolId}`);
-
-      let volume24hUSD: number | undefined = cachedStats?.volume24hUSD;
-      let fees24hUSD: number | undefined = cachedStats?.fees24hUSD; // Assuming fees are part of this cache if available
-      let volume7dUSD: number | undefined = cachedStats?.volume7dUSD;
-      let fees7dUSD: number | undefined = cachedStats?.fees7dUSD;
-      let tvlUSD: number | undefined = cachedStats?.tvlUSD;
-      let calculatedApr = cachedStats?.apr || "Loading...";
-      let volume48hUSD: number | undefined = cachedStats?.volume48hUSD; // Added for 48h volume
-      let volumeChangeDirection: 'up' | 'down' | 'neutral' | 'loading' = cachedStats?.volumeChangeDirection || 'loading'; // Added for volume change
-      let tvlYesterdayUSD: number = cachedStats?.tvlYesterdayUSD ?? 0; // Added for TVL from yesterday, initialized to 0
-      let tvlChangeDirection: 'up' | 'down' | 'neutral' | 'loading' = cachedStats?.tvlChangeDirection || 'loading'; // Added for TVL change
-
-      try {
-        // Fetch data only if we don't have all the required data cached or if a direction is still loading
-        if (volume24hUSD === undefined || tvlUSD === undefined || fees24hUSD === undefined || volume48hUSD === undefined || tvlYesterdayUSD === undefined || volumeChangeDirection === 'loading' || tvlChangeDirection === 'loading') { // Added checks for loading states
-          console.log(`Fetching core stats (vol/tvl/fees), 48h volume, and chart data for ${apiPoolId}`);
-          const [res24h, res7d, resTvl, res48h, resChartData] = await Promise.all([
-            fetch(`/api/liquidity/get-rolling-volume-fees?poolId=${apiPoolId}&days=1`),
-            fetch(`/api/liquidity/get-rolling-volume-fees?poolId=${apiPoolId}&days=7`),
-            fetch(`/api/liquidity/get-pool-tvl?poolId=${apiPoolId}`),
-            fetch(`/api/liquidity/get-rolling-volume-fees?poolId=${apiPoolId}&days=2`), // Fetch 48h volume
-            fetch(`/api/liquidity/chart-data/${apiPoolId}?numDays=2`), // Fetch last 2 days of chart data for TVL comparison
-          ]);
-
-          if (!res24h.ok || !res7d.ok || !resTvl.ok || !res48h.ok || !resChartData.ok) { // Added resChartData.ok
-            console.error(`Failed to fetch some core stats, 48h volume, or chart data for ${apiPoolId}.`);
-            // On fetch failure, set change directions to neutral
-            volumeChangeDirection = 'neutral';
-            tvlChangeDirection = 'neutral';
-            // Don't return here, allow partial updates if some data was cached
-          } else {
-            const data24h = await res24h.json();
-            const data7d = await res7d.json();
-            const dataTvl = await resTvl.json();
-            const data48h = await res48h.json(); // Process 48h data
-            const chartData = await resChartData.json(); // Process chart data
-
-            console.log(`[LiquidityPage] Raw TVL data for ${apiPoolId}:`, dataTvl);
-            console.log(`[LiquidityPage] Raw chart data for ${apiPoolId}:`, chartData);
-
-            volume24hUSD = parseFloat(data24h.volumeUSD);
-            fees24hUSD = parseFloat(data24h.feesUSD);
-            volume7dUSD = parseFloat(data7d.volumeUSD);
-            fees7dUSD = parseFloat(data7d.feesUSD);
-            tvlUSD = parseFloat(dataTvl.tvlUSD);
-            volume48hUSD = parseFloat(data48h.volumeUSD); // Store 48h volume
-
-            // Calculate volume change direction if both 24h and 48h volumes are available and valid
-            if (volume24hUSD !== undefined && volume48hUSD !== undefined && !isNaN(volume24hUSD) && !isNaN(volume48hUSD)) { // Added isNaN checks
-                const volumePrevious24h = volume48hUSD - volume24hUSD; // Volume from 24h to 48h ago
-                if (volume24hUSD > volumePrevious24h) {
-                    volumeChangeDirection = 'up';
-                } else if (volume24hUSD < volumePrevious24h) {
-                    volumeChangeDirection = 'down';
-                } else {
-                    volumeChangeDirection = 'neutral';
-                }
-            } else {
-                 volumeChangeDirection = 'neutral'; // Cannot determine change
-            }
-
-            // Calculate TVL change direction if current TVL and yesterday's TVL are available and valid
-            if (tvlUSD !== undefined && chartData && chartData.length >= 2 && !isNaN(tvlUSD)) { // Added isNaN check for tvlUSD
-                // Find yesterday's data more robustly
-                const yesterday = new Date();
-                yesterday.setDate(yesterday.getDate() - 1);
-                const yesterdayDateString = yesterday.toISOString().split('T')[0];
-
-                const yesterdayData = chartData.find((d: { date: string, tvlUSD: number }) => d.date === yesterdayDateString && typeof d.tvlUSD === 'number');
-
-                if (yesterdayData && typeof yesterdayData.tvlUSD === 'number') {
-                    // Now that we found yesterdayData with valid tvlUSD, assign it
-                    tvlYesterdayUSD = yesterdayData.tvlUSD;
-                    // Perform comparison using the guaranteed number type
-                    if (tvlUSD > tvlYesterdayUSD) {
-                        tvlChangeDirection = 'up';
-                    } else if (tvlUSD < tvlYesterdayUSD) {
-                        tvlChangeDirection = 'down';
-                    } else {
-                        tvlChangeDirection = 'neutral';
-                    }
-                } else {
-                    // If yesterday's data isn't found, or its tvlUSD is invalid
-                    tvlChangeDirection = 'neutral'; // Assume neutral if no reliable historical data for comparison
-                }
-            } else if (tvlUSD !== undefined && !isNaN(tvlUSD)) { // If we have current TVL but not enough historical data (less than 2 days)
-                tvlChangeDirection = 'neutral'; // Assume neutral if not enough data
-            } else {
-                // If current TVL is not available or is invalid
-                tvlChangeDirection = 'neutral'; // Cannot determine change without current TVL
-            }
-          }
-        }
-
-        // Fetch dynamic fee for APR calculation
-        const [token0SymbolStr, token1SymbolStr] = pool.pair.split(' / ');
-        const fromTokenSymbolForFee = TOKEN_DEFINITIONS[token0SymbolStr?.trim() as TokenSymbol]?.symbol;
-        const toTokenSymbolForFee = TOKEN_DEFINITIONS[token1SymbolStr?.trim() as TokenSymbol]?.symbol;
-
-        let dynamicFeeBps: number | null = null;
-        if (fromTokenSymbolForFee && toTokenSymbolForFee && baseSepolia.id) {
-          const feeCacheKey = getPoolDynamicFeeCacheKey(fromTokenSymbolForFee, toTokenSymbolForFee, baseSepolia.id);
-          const cachedFee = getFromCache<{ dynamicFee: string }>(feeCacheKey);
-
-          if (cachedFee) {
-            console.log(`[Cache HIT] Using cached dynamic fee for APR calc (${pool.pair}):`, cachedFee.dynamicFee);
-            dynamicFeeBps = Number(cachedFee.dynamicFee);
-          } else {
-            console.log(`[Cache MISS] Fetching dynamic fee from API for APR calc (${pool.pair})`);
-            const feeResponse = await fetch('/api/swap/get-dynamic-fee', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                fromTokenSymbol: fromTokenSymbolForFee,
-                toTokenSymbol: toTokenSymbolForFee,
-                chainId: baseSepolia.id,
-              }),
-            });
-            if (feeResponse.ok) {
-              const feeData = await feeResponse.json();
-              dynamicFeeBps = Number(feeData.dynamicFee);
-              if (!isNaN(dynamicFeeBps)) {
-                 setToCache(feeCacheKey, { dynamicFee: feeData.dynamicFee });
-                 console.log(`[Cache SET] Cached dynamic fee for APR calc (${pool.pair}):`, feeData.dynamicFee);
-              } else {
-                dynamicFeeBps = null; // Invalid fee from API
-              }
-            } else {
-              console.error(`Failed to fetch dynamic fee for APR calc (${pool.pair}):`, await feeResponse.text());
-            }
-          }
-        }
-
-        // Calculate APR if all parts are available
-        if (volume24hUSD !== undefined && dynamicFeeBps !== null && tvlUSD !== undefined && tvlUSD > 0) {
-          const feeRate = dynamicFeeBps / 10000 / 100;
-          const dailyFees = volume24hUSD * feeRate;
-          const yearlyFees = dailyFees * 365;
-          const apr = (yearlyFees / tvlUSD) * 100;
-          calculatedApr = apr.toFixed(2) + '%';
-          console.log(`Calculated APR for ${pool.pair}: ${calculatedApr} (Vol24h: ${volume24hUSD}, FeeBPS: ${dynamicFeeBps}, TVL: ${tvlUSD})`);
-        } else {
-          console.warn(`Could not calculate APR for ${pool.pair} due to missing data. Vol: ${volume24hUSD}, Fee: ${dynamicFeeBps}, TVL: ${tvlUSD}`);
-          calculatedApr = "N/A"; // Set to N/A if calculation not possible
-        }
-        
-        const completeFetchedStats: Partial<Pool> = {
-          volume24hUSD,
-          fees24hUSD,
-          volume7dUSD,
-          fees7dUSD,
-          tvlUSD,
-          apr: calculatedApr,
-          volume48hUSD, // Include 48h volume in cached stats
-          volumeChangeDirection, // Include volume change direction
-          tvlYesterdayUSD, // Include yesterday's TVL in cached stats
-          tvlChangeDirection, // Include TVL change direction
-        };
-        // Cache the combined stats including the newly calculated APR and volume change
-        setToCache(statsCacheKey, completeFetchedStats);
-        console.log(`[Cache SET] Cached combined stats for pool: ${pool.pair}, API ID: ${apiPoolId}`);
-        return completeFetchedStats;
-
-      } catch (error: any) { // Catch any errors during the fetch or processing
-        console.error(`Error fetching or processing stats for ${pool.pair}:`, error);
-        // Keep existing cached data if available, otherwise set to undefined/neutral
-        const errorStats: Partial<Pool> = {
-            volume24hUSD: cachedStats?.volume24hUSD,
-            fees24hUSD: cachedStats?.fees24hUSD,
-            volume7dUSD: cachedStats?.volume7dUSD,
-            fees7dUSD: cachedStats?.fees7dUSD,
-            tvlUSD: cachedStats?.tvlUSD,
-            apr: cachedStats?.apr || "N/A", // Keep cached APR or set to N/A
-            volume48hUSD: cachedStats?.volume48hUSD,
-            volumeChangeDirection: cachedStats?.volumeChangeDirection || 'neutral',
-            tvlYesterdayUSD: cachedStats?.tvlYesterdayUSD,
-            tvlChangeDirection: cachedStats?.tvlChangeDirection || 'neutral'
-        };
-         return errorStats; // Return the partial stats with neutral/cached values on error
-      }
-    };
-
-    const updateAllPoolStats = async () => {
-      console.log("Starting to fetch/update stats for all pools...");
-      const updatedPoolsPromises = poolsData.map(pool => 
-        fetchPoolStats(pool).then(stats => ({ ...pool, ...stats }))
-      );
-      const updatedPools = await Promise.all(updatedPoolsPromises);
-      console.log("Fetched stats, updating poolsData state:", updatedPools);
-      setPoolsData(updatedPools);
-    };
-
-    if (poolsData.length > 0) { // Only run if there are pools to update
-        updateAllPoolStats(); // Initial fetch
-    }
-
-    // Set up interval for periodic updates
-    const intervalId = setInterval(() => {
-      console.log("[LiquidityPage] Interval: Refreshing pool stats...");
-      updateAllPoolStats();
-    }, 60000); // Refresh every 60 seconds
-
-    // Cleanup interval on component unmount
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, []); // Run once on component mount to set up initial fetch and interval
-
-  // Calculate pools with their position counts
-  const poolsWithPositionCounts = useMemo(() => {
-    return poolsData.map(pool => { // Use poolsData state here
-      const [poolToken0Raw, poolToken1Raw] = pool.pair.split(' / ');
-      const poolToken0 = poolToken0Raw?.trim().toUpperCase();
-      const poolToken1 = poolToken1Raw?.trim().toUpperCase();
-      
-      const count = userPositions.filter(pos => {
-        const posToken0 = pos.token0.symbol?.trim().toUpperCase();
-        const posToken1 = pos.token1.symbol?.trim().toUpperCase();
-        return (posToken0 === poolToken0 && posToken1 === poolToken1) ||
-               (posToken0 === poolToken1 && posToken1 === poolToken0);
+      const positionCount = positions.filter(pos => {
+        const p0 = pos.token0.symbol?.toUpperCase();
+        const p1 = pos.token1.symbol?.toUpperCase();
+        return (p0 === t0 && p1 === t1) || (p0 === t1 && p1 === t0);
       }).length;
-      
-      return { ...pool, positionsCount: count };
+
+      return {
+        ...pool,
+        tvlUSD: batch?.tvlUSD,
+        volume24hUSD: batch?.volume24hUSD,
+        fees24hUSD: batch?.fees24hUSD,
+        apr: apr?.apr7d ? `${apr.apr7d.toFixed(2)}%` : pool.apr,
+        positionsCount: positionCount,
+      };
     });
-  }, [poolsData, userPositions]); // Depend on poolsData and userPositions
+  }, [batchData, aprData, positions]);
 
-  // Calculate totals for stats
-  const totals = React.useMemo(() => ({
-    volume: chartData.reduce((acc, curr) => acc + curr.volume, 0),
-    tvl: chartData.reduce((acc, curr) => acc + curr.tvl, 0),
-  }), []);
-
-  // Define the columns for the table
-  const columns: ColumnDef<Pool>[] = [
+  const columns: ColumnDef<Pool>[] = useMemo(() => [
     {
       accessorKey: "pair",
       header: "Pool",
-      cell: ({ row }) => {
-        const pool = row.original;
-        return (
-          <div className="flex items-center gap-2">
-            <div className="relative w-14 h-7">
-              <div className="absolute top-0 left-0 w-7 h-7 rounded-full overflow-hidden bg-background border border-border/50">
-                <Image
-                  src={pool.tokens[0].icon}
-                  alt={pool.tokens[0].symbol}
-                  width={28}
-                  height={28}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <div className="absolute top-0 left-4 w-7 h-7 rounded-full overflow-hidden bg-background border border-border/50">
-                <Image
-                  src={pool.tokens[1].icon}
-                  alt={pool.tokens[1].symbol}
-                  width={28}
-                  height={28}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-            </div>
-            <div className="flex flex-col">
-              <span className="font-medium">{pool.pair}</span>
-              <div className="text-xs h-4 text-muted-foreground flex items-center">
-                {isLoadingPositions ? (
-                  <div className="h-3 w-16 bg-muted/60 rounded loading-skeleton"></div>
-                ) : pool.positionsCount !== undefined && pool.positionsCount > 0 ? (
-                    <span>
-                      {pool.positionsCount} {pool.positionsCount === 1 ? 'position' : 'positions'}
-                    </span>
-                  ) : (
-                    <span className="invisible">0 positions</span>
-                  )
-                }
-              </div>
+      cell: ({ row }) => (
+        <div className="flex items-center gap-2">
+          <PoolTokenIcons tokens={row.original.tokens} />
+          <div className="flex flex-col">
+            <span className="font-medium">{row.original.pair}</span>
+            <div className="text-xs h-4 text-muted-foreground">
+              {loadingPositions ? <Skeleton className="h-3 w-16" />
+                : row.original.positionsCount ? `${row.original.positionsCount} position${row.original.positionsCount > 1 ? 's' : ''}`
+                : null}
             </div>
           </div>
-        );
-      },
-    },
-    {
-      accessorKey: "volume24h",
-      header: () => <div className="text-right w-full">Volume (24h)</div>,
-      cell: ({ row }) => (
-        <div className="text-right flex items-center justify-end gap-1">
-          {typeof row.original.volume24hUSD === 'number' ? (
-            <>
-              {formatUSD(row.original.volume24hUSD)}
-              {/* Conditionally render arrow based on volumeChangeDirection */}
-              {row.original.volumeChangeDirection === 'up' && (
-                <Image
-                  src="/arrow_up.svg"
-                  alt="Volume Increase Icon"
-                  width={8}
-                  height={8}
-                  className="text-green-500"
-                />
-              )}
-              {row.original.volumeChangeDirection === 'down' && (
-                <Image
-                  src="/arrow_down.svg"
-                  alt="Volume Decrease Icon"
-                  width={8}
-                  height={8}
-                  className="text-red-500"
-                />
-              )}
-              {/* Neutral or loading state can render nothing or a placeholder */}
-               {row.original.volumeChangeDirection === 'loading' && (
-                 <div className="inline-block h-3 w-3 bg-muted/60 rounded-full loading-skeleton"></div> // Optional loading indicator
-              )}
-            </>
-          ) : (
-            <div className="inline-block h-4 w-16 bg-muted/60 rounded loading-skeleton"></div>
-          )}
-        </div>
-      ),
-      meta: {
-        hideOnMobile: true,
-        hidePriority: 3,
-      }
-    },
-    {
-      accessorKey: "volume7d",
-      header: () => <div className="text-right w-full">Volume (7d)</div>,
-      cell: ({ row }) => (
-        <div className="text-right flex items-center justify-end">
-          {typeof row.original.volume7dUSD === 'number' ? (
-            formatUSD(row.original.volume7dUSD)
-          ) : (
-            <div className="inline-block h-4 w-16 bg-muted/60 rounded loading-skeleton"></div>
-          )}
-        </div>
-      ),
-      meta: {
-        hideOnMobile: true,
-        hidePriority: 2,
-      }
-    },
-    {
-      accessorKey: "fees24h",
-      header: () => <div className="text-right w-full">Fees (24h)</div>,
-      cell: ({ row }) => (
-         <div className="text-right flex items-center justify-end">
-          {typeof row.original.fees24hUSD === 'number' ? (
-            formatUSD(row.original.fees24hUSD)
-          ) : (
-            <div className="inline-block h-4 w-12 bg-muted/60 rounded loading-skeleton"></div>
-          )}
-        </div>
-      ),
-      meta: {
-        hideOnMobile: true,
-        hidePriority: 2,
-      }
-    },
-    {
-      accessorKey: "fees7d",
-      header: () => <div className="text-right w-full">Fees (7d)</div>,
-      cell: ({ row }) => (
-        <div className="text-right flex items-center justify-end">
-          {typeof row.original.fees7dUSD === 'number' ? (
-            formatUSD(row.original.fees7dUSD)
-          ) : (
-            <div className="inline-block h-4 w-12 bg-muted/60 rounded loading-skeleton"></div>
-          )}
         </div>
       ),
     },
     {
-      accessorKey: "liquidity",
-      header: () => <div className="text-right w-full">Liquidity</div>,
+      accessorKey: "volume24hUSD",
+      header: () => <div className="text-right hidden lg:block">Volume (24h)</div>,
       cell: ({ row }) => (
-         <div className="text-right flex items-center justify-end gap-1">
-          {typeof row.original.tvlUSD === 'number' ? (
-            <>
-              {formatUSD(row.original.tvlUSD)}
-              {/* Conditionally render arrow based on tvlChangeDirection */}
-              {(row.original.tvlChangeDirection === 'up' || row.original.tvlChangeDirection === 'neutral') && (
-                <Image
-                  src="/arrow_up.svg"
-                  alt="Liquidity Increase Icon"
-                  width={8}
-                  height={8}
-                  className="text-green-500"
-                />
-              )}
-              {row.original.tvlChangeDirection === 'down' && (
-                <Image
-                  src="/arrow_down.svg"
-                  alt="Liquidity Decrease Icon"
-                  width={8}
-                  height={8}
-                  className="text-red-500"
-                />
-              )}
-               {/* Loading state */}
-               {row.original.tvlChangeDirection === 'loading' && (
-                 <div className="inline-block h-3 w-3 bg-muted/60 rounded-full loading-skeleton"></div> // Optional loading indicator
-              )}
-            </>
-          ) : (
-            <div className="inline-block h-4 w-20 bg-muted/60 rounded loading-skeleton"></div>
-          )}
+        <div className="text-right hidden lg:block">
+          {row.original.volume24hUSD !== undefined ? formatUSD(row.original.volume24hUSD) : <Skeleton className="inline-block h-4 w-16" />}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "fees24hUSD",
+      header: () => <div className="text-right hidden xl:block">Fees (24h)</div>,
+      cell: ({ row }) => (
+        <div className="text-right hidden xl:block">
+          {row.original.fees24hUSD !== undefined ? formatUSD(row.original.fees24hUSD) : <Skeleton className="inline-block h-4 w-12" />}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "tvlUSD",
+      header: () => <div className="text-right">Liquidity</div>,
+      cell: ({ row }) => (
+        <div className="text-right">
+          {row.original.tvlUSD !== undefined ? formatUSD(row.original.tvlUSD) : <Skeleton className="inline-block h-4 w-20" />}
         </div>
       ),
     },
     {
       accessorKey: "apr",
-      header: () => <div className="text-right w-full flex items-center justify-end">Yield</div>,
-      cell: ({ row }) => {
-        const isAprCalculated = row.original.apr !== undefined && row.original.apr !== "Loading..." && row.original.apr !== "N/A";
-        const formattedAPR = isAprCalculated ? parseFloat(row.original.apr.replace('%', '')).toFixed(2) + '%' : undefined;
-
-        // COMMENTED OUT: Hover Add Liquidity button functionality - preserved for future use
-        // const initialWidthClass = 'w-16';
-        // const initialHeightClass = 'h-6';
-
-        return (
-          <div className="text-right flex items-center justify-end">
-            {isAprCalculated ? (
-              <div className="flex items-center justify-center w-16 h-6 rounded-md bg-green-500/20 text-green-500">
-                {formattedAPR}
-              </div>
-            ) : (
-              <div className="inline-block h-4 w-16 bg-muted/60 rounded loading-skeleton"></div>
-            )}
-          </div>
-
-          // COMMENTED OUT: Hover Add Liquidity functionality - preserved for future use
-          // <div 
-          //   onClick={(e) => handleAddLiquidity(e, row.original.id)}
-          //   className={`relative flex items-center ${initialWidthClass} ${initialHeightClass} rounded-md ${isAprCalculated ? 'bg-green-500/20 text-green-500' : 'bg-muted/60'} overflow-hidden ml-auto
-          //               group-hover:w-32 group-hover:h-8
-          //               group-hover:bg-transparent group-hover:text-foreground group-hover:border group-hover:border-border
-          //               group-hover:hover:bg-accent group-hover:hover:text-accent-foreground
-          //               transition-all duration-300 ease-in-out cursor-pointer`}
-          // >
-          //   {isAprCalculated ? (
-          //     <>
-          //        <span className="absolute inset-0 flex items-center justify-center opacity-100 group-hover:opacity-0 transition-opacity duration-300 ease-in-out">
-          //         {formattedAPR}
-          //       </span>
-          //       <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out px-2 whitespace-nowrap">
-          //           <PlusIcon className="w-4 h-4 mr-2" />
-          //           Add Liquidity
-          //       </div>
-          //     </>
-          //   ) : (
-          //    <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out px-2 whitespace-nowrap">
-          //        <PlusIcon className="w-4 h-4 mr-2" />
-          //        Add Liquidity
-          //    </div>
-          //   )}
-          // </div>
-        );
-      },
+      header: () => <div className="text-right">Yield</div>,
+      cell: ({ row }) => (
+        <div className="text-right flex justify-end">
+          {isAprLoaded(row.original.apr) ? (
+            <div className="w-16 h-6 rounded-md bg-green-500/20 text-green-500 flex items-center justify-center">
+              {row.original.apr}
+            </div>
+          ) : (
+            <Skeleton className="h-4 w-16" />
+          )}
+        </div>
+      ),
     },
-  ];
+  ], [loadingPositions]);
 
-  // Filter columns based on screen size and priority
-  const visibleColumns = useMemo(() => {
-    if (isMobile) {
-       return columns;
-    }
-    
-    if (windowWidth < 900) { 
-       return columns.filter(column => (column.meta as any)?.hidePriority === undefined || 
-                                       (column.meta as any)?.hidePriority > 3);
-    } else if (windowWidth < 1100) { 
-       return columns.filter(column => (column.meta as any)?.hidePriority === undefined || 
-                                       (column.meta as any)?.hidePriority > 2);
-    } else if (windowWidth < 1280) { 
-       return columns.filter(column => (column.meta as any)?.hidePriority === undefined || 
-                                       (column.meta as any)?.hidePriority > 1);
-    }
-    
-    return columns;
-  }, [columns, isMobile, windowWidth]);
-  
-  // Initialize the table with filtered columns
   const table = useReactTable({
-    data: poolsWithPositionCounts,
-    columns: visibleColumns,
+    data: pools,
+    columns,
     getCoreRowModel: getCoreRowModel(),
-    onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
-    state: {
-      sorting,
-    },
+    onSortingChange: setSorting,
+    state: { sorting },
   });
 
-  const handleAddLiquidity = (e: React.MouseEvent, poolId: string) => {
-    e.stopPropagation(); // Prevent row click if APR cell itself is handling it
-    setSelectedPoolId(poolId); 
-    const pool = poolsWithPositionCounts.find(p => p.id === poolId);
-    setSelectedPoolApr(pool?.apr); // Store the APR for the selected pool
-    setAddLiquidityOpen(true);
-  };
+  const onPoolClick = (poolId: string) => router.push(`/liquidity/${poolId}`);
 
-  const handlePoolClick = (poolId: string) => {
-    router.push(`/liquidity/${poolId}`);
-  };
+  if (isMobile) {
+    return (
+      <AppLayout>
+        <MobileLiquidityList pools={pools} onSelectPool={onPoolClick} />
+      </AppLayout>
+    );
+  }
 
   return (
     <AppLayout>
-      <div className="flex flex-1 flex-col">
-        <div className="flex flex-1 flex-col p-6 px-10">
-          <div className="mb-6 mt-6">
-            {!isMobile && (
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <h2 className="text-xl font-semibold">Liquidity Pools</h2>
-                  <p className="text-sm text-muted-foreground">
-                    Explore and manage your liquidity positions.
-                  </p>
-                </div>
-              </div>
-            )}
-            
-            {isMobile ? (
-              <MobileLiquidityList 
-                pools={poolsWithPositionCounts}
-                onSelectPool={handlePoolClick}
-              />
-            ) : (
-              <div className="rounded-md border">
-                <Table>
-                  <TableHeader>
-                    {table.getHeaderGroups().map((headerGroup) => (
-                      <TableRow key={headerGroup.id}>
-                        {headerGroup.headers.map((header) => (
-                          <TableHead 
-                            key={header.id} 
-                            className={`${header.column.id !== 'pair' ? 'text-right' : ''}`}>
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext()
-                                )}
-                          </TableHead>
-                        ))}
-                      </TableRow>
+      <div className="flex flex-1 flex-col p-6 px-10">
+        <div className="mb-6 mt-6">
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold">Liquidity Pools</h2>
+            <p className="text-sm text-muted-foreground">Explore and manage your liquidity positions.</p>
+          </div>
+
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map(hg => (
+                  <TableRow key={hg.id}>
+                    {hg.headers.map(h => (
+                      <TableHead key={h.id} className={h.column.id !== 'pair' ? 'text-right' : ''}>
+                        {h.isPlaceholder ? null : flexRender(h.column.columnDef.header, h.getContext())}
+                      </TableHead>
                     ))}
-                  </TableHeader>
-                  <TableBody>
-                    {table.getRowModel().rows?.length ? (
-                      table.getRowModel().rows.map((row) => (
-                        <TableRow
-                          key={row.id}
-                          className={`group cursor-pointer transition-colors ${
-                            row.original.highlighted ? 'bg-accent/10 hover:bg-accent/15' : 'hover:bg-muted/10'
-                          }`}
-                        >
-                          {row.getVisibleCells().map((cell) => (
-                            <TableCell 
-                              key={cell.id} 
-                              onClick={() => handlePoolClick(row.original.id)}
-                              className={`${cell.column.id !== 'pair' ? 'text-right' : ''} relative`}
-                            >
-                              {flexRender(
-                                cell.column.columnDef.cell,
-                                cell.getContext()
-                              )}
-                            </TableCell>
-                          ))}
-                        </TableRow>
-                      ))
-                    ) : (
-                      <TableRow>
-                        <TableCell
-                          colSpan={columns.length}
-                          className="h-24 text-center"
-                        >
-                          No pools available.
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map(row => (
+                    <TableRow
+                      key={row.id}
+                      onClick={() => onPoolClick(row.original.id)}
+                      className={`cursor-pointer transition-colors ${row.original.highlighted ? 'bg-accent/10 hover:bg-accent/15' : 'hover:bg-muted/10'}`}
+                    >
+                      {row.getVisibleCells().map(cell => (
+                        <TableCell key={cell.id} className={cell.column.id !== 'pair' ? 'text-right' : ''}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
+                      ))}
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">No pools available.</TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
           </div>
         </div>
       </div>
-      {/* Add Liquidity Modal */}
-      <AddLiquidityModal
-        isOpen={addLiquidityOpen}
-        onOpenChange={setAddLiquidityOpen}
-        selectedPoolId={selectedPoolId}
-        poolApr={selectedPoolApr}
-        onLiquidityAdded={() => {
-          // Fetch all user positions again after adding liquidity
-          if (isConnected && accountAddress) {
-            fetch(`/api/liquidity/get-positions?ownerAddress=${accountAddress}`)
-              .then(res => res.json())
-              .then((data: ProcessedPosition[] | { message: string }) => {
-                if (Array.isArray(data)) {
-                  setUserPositions(data);
-                }
-              })
-              .catch(error => {
-                console.error("Failed to refresh positions:", error);
-              });
-          }
-        }}
-        sdkMinTick={SDK_MIN_TICK}
-        sdkMaxTick={SDK_MAX_TICK}
-        defaultTickSpacing={DEFAULT_TICK_SPACING}
-      />
     </AppLayout>
   );
-} 
+}

--- a/components/AccountStatus.tsx
+++ b/components/AccountStatus.tsx
@@ -103,8 +103,8 @@ export function AccountStatus() {
 
   // Mock data for leveling system
   const levelData = {
-    currentLevel: 3,
-    currentXP: 750,
+    currentLevel: 0,
+    currentXP: 0,
     nextLevelXP: 1000
   }
 
@@ -174,11 +174,17 @@ export function AccountStatus() {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <div className="px-2 py-1.5 flex items-center">
+            <div className="relative px-2 py-1.5 flex items-center cursor-pointer group">
               <LevelProgress {...levelData} className="flex-grow" />
               <span className="ml-2 text-xs font-medium text-muted-foreground whitespace-nowrap">
                 Lvl {levelData.currentLevel}
               </span>
+              {/* Hover overlay */}
+              <div className="absolute inset-0 bg-black/60 rounded-sm opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Coming Soon
+                </span>
+              </div>
             </div>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => disconnect()}>

--- a/components/MobileLiquidityList.tsx
+++ b/components/MobileLiquidityList.tsx
@@ -3,21 +3,13 @@
 import Image from "next/image";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import type { Pool } from "@/types"; // Import the centralized Pool type
+import { formatUSD } from "@/lib/format";
+import type { Pool } from "@/types";
 
 interface MobileLiquidityListProps {
   pools: Pool[];
   onSelectPool: (poolId: string) => void;
 }
-
-// Helper function to format USD values, similar to the one in app/liquidity/page.tsx
-const formatUSD = (value: number) => {
-  if (value < 0.01 && value > 0) return "< $0.01"; // Handle very small positive values
-  if (value === 0) return "$0.00";
-  if (Math.abs(value) < 0.01) return "< $0.01"; // For small negative values if they ever occur
-  if (Math.abs(value) < 1000) return `$${value.toFixed(2)}`;
-  return `$${(value).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-};
 
 export function MobileLiquidityList({ pools, onSelectPool }: MobileLiquidityListProps) {
   if (!pools || pools.length === 0) {

--- a/components/data/hooks.ts
+++ b/components/data/hooks.ts
@@ -1,0 +1,138 @@
+import { useQuery } from '@tanstack/react-query'
+import { getPoolSubgraphId, getEnabledPools } from '@/lib/pools-config'
+import type { ProcessedPosition } from '@/pages/api/liquidity/get-positions'
+
+// Types
+interface PoolBatchData {
+  poolId: string
+  tvlUSD: number
+  volume24hUSD: number
+  fees24hUSD: number
+  dynamicFeeBps: number
+}
+
+interface PoolAprData {
+  poolId: string
+  apr7d: number
+}
+
+// Fetch batch pool data (TVL, volume, fees)
+async function fetchPoolsBatch(poolIds: string[]): Promise<PoolBatchData[]> {
+  if (poolIds.length === 0) return []
+
+  const res = await fetch('/api/liquidity/get-pools-batch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ poolIds }),
+  })
+
+  if (!res.ok) throw new Error('Failed to fetch pools batch')
+
+  const data: PoolBatchData[] = await res.json()
+
+  // Validate: at least one pool should have non-zero TVL
+  // (TVL should never be 0 for active pools - indicates subgraph lag)
+  const hasValidData = data.some(p => p.tvlUSD > 0)
+  if (!hasValidData && data.length > 0) {
+    throw new Error('Invalid data: all TVL values are zero')
+  }
+
+  return data
+}
+
+// Fetch APR data with rate limiting
+async function fetchPoolsAprBatch(poolIds: string[]): Promise<PoolAprData[]> {
+  if (poolIds.length === 0) return []
+
+  const results: PoolAprData[] = []
+  let hasAnyValidApr = false
+
+  for (let i = 0; i < poolIds.length; i++) {
+    const poolId = poolIds[i]
+    const subgraphId = getPoolSubgraphId(poolId) || poolId
+
+    try {
+      const res = await fetch(`/api/liquidity/pool-metrics?poolId=${subgraphId}`)
+      if (!res.ok) {
+        results.push({ poolId, apr7d: 0 })
+        continue
+      }
+
+      const metrics = await res.json()
+      const { totalFeesToken0 = 0, avgTVLToken0 = 0, days = 0 } = metrics || {}
+
+      let apr7d = 0
+      if (avgTVLToken0 > 0 && days > 0) {
+        apr7d = ((totalFeesToken0 / days) * 365 / avgTVLToken0) * 100
+        if (!isFinite(apr7d) || apr7d < 0) apr7d = 0
+      }
+
+      if (apr7d > 0) hasAnyValidApr = true
+      results.push({ poolId, apr7d })
+    } catch {
+      results.push({ poolId, apr7d: 0 })
+    }
+
+    // Rate limit: 150ms between requests
+    if (i < poolIds.length - 1) {
+      await new Promise(r => setTimeout(r, 150))
+    }
+  }
+
+  // Validate: at least one pool should have non-zero APR
+  if (!hasAnyValidApr && results.length > 0) {
+    throw new Error('Invalid data: all APR values are zero')
+  }
+
+  return results
+}
+
+// Fetch user positions
+async function fetchUserPositions(ownerAddress: string): Promise<ProcessedPosition[]> {
+  const res = await fetch(`/api/liquidity/get-positions?ownerAddress=${ownerAddress}`)
+  if (!res.ok) throw new Error('Failed to fetch positions')
+  const data = await res.json()
+  return Array.isArray(data) ? data : []
+}
+
+// Hook: Batch pool data (5-min stale time)
+export function usePoolsBatch(poolIds: string[]) {
+  return useQuery({
+    queryKey: ['pools-batch', poolIds],
+    queryFn: () => fetchPoolsBatch(poolIds),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    enabled: poolIds.length > 0,
+    retry: 5,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10000), // 1s, 2s, 4s, 8s, 10s
+  })
+}
+
+// Hook: APR data (1-hour stale time - slower changing)
+export function usePoolsAprBatch(poolIds: string[]) {
+  return useQuery({
+    queryKey: ['pools-apr-batch', poolIds],
+    queryFn: () => fetchPoolsAprBatch(poolIds),
+    staleTime: 60 * 60 * 1000,
+    gcTime: 2 * 60 * 60 * 1000,
+    enabled: poolIds.length > 0,
+    retry: 5,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10000),
+  })
+}
+
+// Hook: User positions
+export function useUserPositions(ownerAddress: string | undefined) {
+  return useQuery({
+    queryKey: ['user-positions', ownerAddress],
+    queryFn: () => fetchUserPositions(ownerAddress!),
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+    enabled: !!ownerAddress,
+  })
+}
+
+// Hook: Get enabled pool IDs
+export function useEnabledPoolIds() {
+  return getEnabledPools().map(p => p.id)
+}

--- a/components/dynamic-fee-chart-preview.tsx
+++ b/components/dynamic-fee-chart-preview.tsx
@@ -3,6 +3,8 @@
 import { LineChart, Line, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { ArrowRightIcon } from "lucide-react";
+import Image from "next/image";
+import { getToken } from "@/lib/pools-config";
 
 interface FeeHistoryPoint {
   timeLabel: string;
@@ -14,9 +16,14 @@ interface FeeHistoryPoint {
 interface DynamicFeeChartPreviewProps {
   data: FeeHistoryPoint[];
   onClick?: () => void; // To handle click for opening the modal
+  poolInfo?: {
+    token0Symbol: string;
+    token1Symbol: string;
+    poolName: string;
+  };
 }
 
-export function DynamicFeeChartPreview({ data, onClick }: DynamicFeeChartPreviewProps) {
+export function DynamicFeeChartPreview({ data, onClick, poolInfo }: DynamicFeeChartPreviewProps) {
   if (!data || data.length === 0) {
     return null; // Don't render if no data
   }
@@ -78,7 +85,35 @@ export function DynamicFeeChartPreview({ data, onClick }: DynamicFeeChartPreview
         <div className="space-y-0.5">
             <CardTitle className="text-sm font-medium">Dynamic Fee Trend</CardTitle>
             <CardDescription className="text-xs text-muted-foreground">
-                30-Day Fee Snapshot
+                {poolInfo ? (
+                  <div className="flex items-center">
+                    {/* Overlapping token icons - smaller version */}
+                    <div className="relative w-8 h-4">
+                      <div className="absolute top-0 left-0 w-4 h-4 rounded-full overflow-hidden bg-background border border-border/50">
+                        <Image 
+                          src={getToken(poolInfo.token0Symbol)?.icon || "/placeholder-logo.svg"} 
+                          alt={poolInfo.token0Symbol} 
+                          width={16} 
+                          height={16} 
+                          className="w-full h-full object-cover" 
+                        />
+                      </div>
+                      <div className="absolute top-0 left-2.5 w-4 h-4 rounded-full overflow-hidden bg-background border border-border/50">
+                        <Image 
+                          src={getToken(poolInfo.token1Symbol)?.icon || "/placeholder-logo.svg"} 
+                          alt={poolInfo.token1Symbol} 
+                          width={16} 
+                          height={16} 
+                          className="w-full h-full object-cover" 
+                        />
+                      </div>
+                    </div>
+                    {/* Pool pair name */}
+                    <span>{poolInfo.token0Symbol}/{poolInfo.token1Symbol}</span>
+                  </div>
+                ) : (
+                  "30-Day Fee Snapshot"
+                )}
             </CardDescription>
         </div>
         <ArrowRightIcon className="h-4 w-4 text-muted-foreground group-hover:text-white transition-colors duration-150" />

--- a/components/liquidity/useAddLiquidityTransaction.ts
+++ b/components/liquidity/useAddLiquidityTransaction.ts
@@ -8,10 +8,12 @@ import {
   useSignTypedData
 } from "wagmi";
 import { toast } from "sonner";
-import { TokenSymbol, TOKEN_DEFINITIONS } from "@/lib/swap-constants";
+import { V4_POOL_FEE, V4_POOL_TICK_SPACING, V4_POOL_HOOKS } from "@/lib/swap-constants";
+import { TOKEN_DEFINITIONS } from "@/lib/pools-config";
 import { baseSepolia } from "@/lib/wagmiConfig";
 import { ERC20_ABI } from "@/lib/abis/erc20";
 import { type Hex, formatUnits, parseUnits, encodeFunctionData } from "viem";
+import { TokenSymbol } from "@/lib/pools-config";
 
 // Minimal ABI for Permit2 functions (both single and batch)
 const PERMIT2_PERMIT_ABI_MINIMAL = [

--- a/components/liquidity/useBurnLiquidity.ts
+++ b/components/liquidity/useBurnLiquidity.ts
@@ -3,7 +3,9 @@ import { useAccount, useWriteContract, useWaitForTransactionReceipt, useReadCont
 import { toast } from 'sonner';
 import { V4PositionPlanner } from '@uniswap/v4-sdk';
 import { Token } from '@uniswap/sdk-core';
-import { TOKEN_DEFINITIONS, TokenSymbol, V4_POSITION_MANAGER_ADDRESS, EMPTY_BYTES, V4_POSITION_MANAGER_ABI } from '@/lib/swap-constants';import { baseSepolia } from '@/lib/wagmiConfig';
+import { V4_POSITION_MANAGER_ADDRESS, EMPTY_BYTES, V4_POSITION_MANAGER_ABI } from '@/lib/swap-constants';
+import { getToken, TokenSymbol } from '@/lib/pools-config';
+import { baseSepolia } from '@/lib/wagmiConfig';
 import { getAddress, type Hex, BaseError } from 'viem';
 import JSBI from 'jsbi';
 
@@ -71,18 +73,18 @@ export function useBurnLiquidity({ onLiquidityBurned }: UseBurnLiquidityProps) {
     const toastId = toast.loading("Preparing burn transaction...");
 
     try {
-      const token0Def = TOKEN_DEFINITIONS[positionData.token0Symbol];
-      const token1Def = TOKEN_DEFINITIONS[positionData.token1Symbol];
+      const token0Def = getToken(positionData.token0Symbol);
+      const token1Def = getToken(positionData.token1Symbol);
 
       if (!token0Def || !token1Def) {
         throw new Error("Token definitions not found for one or both tokens in the position.");
       }
-      if (!token0Def.addressRaw || !token1Def.addressRaw) {
+      if (!token0Def.address || !token1Def.address) {
         throw new Error("Token addresses are missing in definitions.");
       }
 
-      const sdkToken0 = new Token(chainId, getAddress(token0Def.addressRaw), token0Def.decimals, token0Def.symbol);
-      const sdkToken1 = new Token(chainId, getAddress(token1Def.addressRaw), token1Def.decimals, token1Def.symbol);
+      const sdkToken0 = new Token(chainId, getAddress(token0Def.address), token0Def.decimals, token0Def.symbol);
+      const sdkToken1 = new Token(chainId, getAddress(token1Def.address), token1Def.decimals, token1Def.symbol);
 
       const planner = new V4PositionPlanner();
       

--- a/components/swap/TokenSelector.tsx
+++ b/components/swap/TokenSelector.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React, { useState } from 'react';
+import Image from 'next/image';
+import { ChevronDownIcon, CheckIcon } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface TokenSelectorToken {
+  address: `0x${string}`;
+  symbol: string;
+  name: string;
+  decimals: number;
+  icon: string;
+  balance?: string;
+  value?: string;
+  usdPrice?: number;
+}
+
+interface TokenSelectorProps {
+  selectedToken: TokenSelectorToken;
+  availableTokens: TokenSelectorToken[];
+  onTokenSelect: (token: TokenSelectorToken) => void;
+  disabled?: boolean;
+  excludeToken?: TokenSelectorToken; // Token to exclude from dropdown (e.g., the other token in swap)
+  className?: string;
+}
+
+export function TokenSelector({
+  selectedToken,
+  availableTokens,
+  onTokenSelect,
+  disabled = false,
+  excludeToken,
+  className
+}: TokenSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Filter out the excluded token (typically the other token in the swap pair)
+  const filteredTokens = excludeToken 
+    ? availableTokens.filter(token => token.address !== excludeToken.address)
+    : availableTokens;
+
+  const handleTokenSelect = (token: TokenSelectorToken) => {
+    onTokenSelect(token);
+    setIsOpen(false);
+  };
+
+  const handleToggle = () => {
+    if (!disabled) {
+      setIsOpen(!isOpen);
+    }
+  };
+
+  return (
+    <div className={cn("relative", className)}>
+      {/* Selected Token Button */}
+      <Button
+        variant="ghost"
+        className={cn(
+          "flex items-center gap-1.5 bg-muted/30 border-0 rounded-lg h-10 px-2 hover:bg-muted/50 transition-colors",
+          {
+            "cursor-not-allowed opacity-50": disabled,
+            "bg-muted/50": isOpen
+          }
+        )}
+        onClick={handleToggle}
+        disabled={disabled}
+      >
+        <Image 
+          src={selectedToken.icon} 
+          alt={selectedToken.symbol} 
+          width={20} 
+          height={20} 
+          className="rounded-full"
+        />
+        <span className="text-sm font-medium">{selectedToken.symbol}</span>
+        <ChevronDownIcon 
+          className={cn(
+            "h-4 w-4 text-muted-foreground transition-transform duration-200",
+            { "rotate-180": isOpen }
+          )} 
+        />
+      </Button>
+
+      {/* Dropdown Menu */}
+      <AnimatePresence>
+        {isOpen && (
+          <>
+            {/* Backdrop */}
+            <div 
+              className="fixed inset-0 z-40 cursor-pointer" 
+              onClick={() => setIsOpen(false)}
+            />
+            
+            {/* Dropdown Content */}
+            <motion.div
+              initial={{ opacity: 0, y: -10, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -10, scale: 0.95 }}
+              transition={{ duration: 0.15, ease: "easeOut" }}
+              className="absolute top-full left-0 right-0 mt-2 bg-background border border-border rounded-lg shadow-lg z-50 py-2 max-h-48 overflow-y-auto"
+            >
+              {filteredTokens.map((token) => {
+                const isSelected = token.address === selectedToken.address;
+                
+                return (
+                  <button
+                    key={token.address}
+                    className={cn(
+                      "w-full flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors text-left",
+                      {
+                        "bg-muted/30": isSelected
+                      }
+                    )}
+                    onClick={() => handleTokenSelect(token)}
+                  >
+                    <Image 
+                      src={token.icon} 
+                      alt={token.symbol} 
+                      width={20} 
+                      height={20} 
+                      className="rounded-full"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">{token.symbol}</span>
+                        {isSelected && (
+                          <CheckIcon className="h-4 w-4 text-primary" />
+                        )}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {token.name}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+} 

--- a/config/pools.json
+++ b/config/pools.json
@@ -1,0 +1,167 @@
+{
+  "meta": {
+    "version": "1.0.0",
+    "description": "Centralized pool configuration for Alphix V4 pools",
+    "chainId": 84532,
+    "chainName": "Base Sepolia"
+  },
+  "contracts": {
+    "poolManager": "0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408",
+    "quoter": "0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba",
+    "positionManager": "0x4b2c77d209d3405f41a037ec6c77f7f5b8e2ca80",
+    "stateView": "0x571291b572ed32ce6751a2cb2486ebee8defb9b4"
+  },
+  "tokens": {
+    "BTCRL": {
+      "symbol": "BTCRL",
+      "name": "Bitcoin Carl",
+      "address": "0x13c26fb69d48ED5a72Ce3302FC795082E2427F4D",
+      "decimals": 8,
+      "displayDecimals": 6,
+      "icon": "/BTCRL.png"
+    },
+    "YUSDC": {
+      "symbol": "YUSDC", 
+      "name": "Yanis USDC",
+      "address": "0x663cF82e49419A3Dc88EEc65c2155b4B2D0fA335",
+      "decimals": 6,
+      "displayDecimals": 2,
+      "icon": "/YUSD.png"
+    },
+    "mUSDT": {
+      "symbol": "mUSDT",
+      "name": "Marina USDT",
+      "address": "0xbaabfA3Ac2Ed3d0154e9E2002f94D8550A79bfa8",
+      "decimals": 6,
+      "displayDecimals": 2,
+      "icon": "/mUSDT.svg"
+    },
+    "aETH": {
+      "symbol": "aETH",
+      "name": "Aurelia Ethereum",
+      "address": "0x28c00749Cb9066d240fE1270b6D7f294b8b34D99",
+      "decimals": 18,
+      "displayDecimals": 4,
+      "icon": "/aETH.svg"
+    },
+    "ETH": {
+      "symbol": "ETH",
+      "name": "Ethereum",
+      "address": "0x0000000000000000000000000000000000000000",
+      "decimals": 18,
+      "displayDecimals": 4,
+      "icon": "/ETH.svg"
+    }
+  },
+  "pools": [
+    {
+      "id": "BTCRL-YUSDC-8388608",
+      "name": "BTCRL/YUSDC",
+      "description": "Bitcoin Carl / Yanis USDC pool",
+      "subgraphId": "0xbcc20db9b797e211e508500469e553111c6fa8d80f7896e6db60167bcf18ce13",
+      "currency0": {
+        "symbol": "BTCRL",
+        "address": "0x13c26fb69d48ED5a72Ce3302FC795082E2427F4D"
+      },
+      "currency1": {
+        "symbol": "YUSDC", 
+        "address": "0x663cF82e49419A3Dc88EEc65c2155b4B2D0fA335"
+      },
+      "fee": 8388608,
+      "tickSpacing": 60,
+      "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
+      "enabled": true,
+      "featured": true
+    },
+    {
+      "id": "YUSDC-mUSDT-8388608",
+      "name": "YUSDC/mUSDT",
+      "description": "Yanis USDC / Marina USDT pool",
+      "subgraphId": "0xc176e54fee5a41917ae5244d8235e0bda1885de86b47f540a09552119d832e6d",
+      "currency0": {
+        "symbol": "YUSDC",
+        "address": "0x663cF82e49419A3Dc88EEc65c2155b4B2D0fA335"
+      },
+      "currency1": {
+        "symbol": "mUSDT", 
+        "address": "0xbaabfA3Ac2Ed3d0154e9E2002f94D8550A79bfa8"
+      },
+      "fee": 8388608,
+      "tickSpacing": 60,
+      "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
+      "enabled": true,
+      "featured": false
+    },
+    {
+      "id": "mUSDT-aETH-8388608",
+      "name": "mUSDT/aETH",
+      "description": "Marina USDT / Aurelia Ethereum pool",
+      "subgraphId": "0x60F36C23D5131AE2EA1CD668AE4013081FD24B9CF94190BB6E08ECE00B8DC27C",
+      "currency0": {
+        "symbol": "mUSDT",
+        "address": "0xbaabfA3Ac2Ed3d0154e9E2002f94D8550A79bfa8"
+      },
+      "currency1": {
+        "symbol": "aETH", 
+        "address": "0x28c00749Cb9066d240fE1270b6D7f294b8b34D99"
+      },
+      "fee": 8388608,
+      "tickSpacing": 60,
+      "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
+      "enabled": true,
+      "featured": false
+    },
+    {
+      "id": "mUSDT-ETH-8388608",
+      "name": "mUSDT/ETH",
+      "description": "Marina USDT / Ethereum pool",
+      "subgraphId": "0xB0679FC770CC387A0DE3099368FD7AD8BD0EFB599525C40F3586AFF55D797EB1",
+      "currency0": {
+        "symbol": "mUSDT",
+        "address": "0xbaabfA3Ac2Ed3d0154e9E2002f94D8550A79bfa8"
+      },
+      "currency1": {
+        "symbol": "ETH", 
+        "address": "0x0000000000000000000000000000000000000000"
+      },
+      "fee": 8388608,
+      "tickSpacing": 60,
+      "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
+      "enabled": true,
+      "featured": false
+    }
+  ],
+  "_comments": {
+    "addingNewPools": "To add a new pool, simply add a new token to the 'tokens' section and a new pool entry here. The system will automatically pick it up!",
+    "configuration": {
+      "currentPools": "BTCRL/YUSDC (featured), YUSDC/mUSDT, mUSDT/aETH, mUSDT/ETH",
+      "allPoolsUseFee": 8388608,
+      "allPoolsUseTickSpacing": 60,
+      "allPoolsUseHooks": "0x94ba380a340E020Dc29D7883f01628caBC975000"
+    },
+    "example": {
+      "newToken": {
+        "WETH": {
+          "symbol": "WETH",
+          "name": "Wrapped Ethereum", 
+          "address": "0xNEW_TOKEN_ADDRESS",
+          "decimals": 18,
+          "displayDecimals": 4,
+          "icon": "/WETH.png"
+        }
+      },
+      "newPool": {
+        "id": "WETH-mUSDT-8388608",
+        "name": "WETH/mUSDT",
+        "description": "Wrapped Ethereum / Marina USDT pool",
+        "currency0": { "symbol": "WETH", "address": "0xNEW_TOKEN_ADDRESS" },
+        "currency1": { "symbol": "mUSDT", "address": "0xbaabfA3Ac2Ed3d0154e9E2002f94D8550A79bfa8" },
+        "fee": 8388608,
+        "tickSpacing": 60,
+        "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
+        "enabled": true,
+        "featured": false
+      }
+    }
+  }
+} 

--- a/config/pools.json
+++ b/config/pools.json
@@ -87,7 +87,7 @@
         "address": "0xbaabfA3Ac2Ed3d0154e9E2002f94D8550A79bfa8"
       },
       "fee": 8388608,
-      "tickSpacing": 60,
+      "tickSpacing": 1,
       "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
       "enabled": true,
       "featured": false
@@ -106,7 +106,7 @@
         "address": "0x28c00749Cb9066d240fE1270b6D7f294b8b34D99"
       },
       "fee": 8388608,
-      "tickSpacing": 60,
+      "tickSpacing": 40,
       "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
       "enabled": true,
       "featured": false
@@ -125,7 +125,7 @@
         "address": "0x0000000000000000000000000000000000000000"
       },
       "fee": 8388608,
-      "tickSpacing": 60,
+      "tickSpacing": 50,
       "hooks": "0x94ba380a340E020Dc29D7883f01628caBC975000",
       "enabled": true,
       "featured": false
@@ -136,7 +136,12 @@
     "configuration": {
       "currentPools": "BTCRL/YUSDC (featured), YUSDC/mUSDT, mUSDT/aETH, mUSDT/ETH",
       "allPoolsUseFee": 8388608,
-      "allPoolsUseTickSpacing": 60,
+      "tickSpacings": {
+        "BTCRL/YUSDC": 60,
+        "YUSDC/mUSDT": 1,
+        "mUSDT/aETH": 40,
+        "mUSDT/ETH": 50
+      },
       "allPoolsUseHooks": "0x94ba380a340E020Dc29D7883f01628caBC975000"
     },
     "example": {

--- a/lib/cache-keys.ts
+++ b/lib/cache-keys.ts
@@ -1,0 +1,26 @@
+/**
+ * Centralized cache key generation
+ * All keys follow pattern: {resource}:{identifier}
+ */
+
+export const cacheKeys = {
+  // Pool batch data (TVL, volume, fees for all pools)
+  poolsBatch: () => 'pools:batch',
+
+  // Individual pool metrics (for APR calculation)
+  poolMetrics: (poolId: string) => `pool:metrics:${poolId.toLowerCase()}`,
+
+  // Pool chart data
+  poolChart: (poolId: string, days: number) => `pool:chart:${poolId.toLowerCase()}:${days}d`,
+
+  // Token prices
+  prices: () => 'prices:all',
+} as const
+
+// TTL constants (in seconds)
+export const cacheTTL = {
+  poolsBatch: { fresh: 300, max: 900 },      // 5min fresh, 15min max
+  poolMetrics: { fresh: 3600, max: 7200 },   // 1h fresh, 2h max
+  poolChart: { fresh: 3600, max: 7200 },     // 1h fresh, 2h max
+  prices: { fresh: 300, max: 900 },          // 5min fresh, 15min max
+} as const

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,17 @@
+// Number and currency formatting utilities
+
+export function formatUSD(value: number): string {
+  if (value < 0.01) return "< $0.01";
+  if (value < 1000) return `$${value.toFixed(2)}`;
+  return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+export function formatPercent(value: number, decimals = 2): string {
+  return `${value.toFixed(decimals)}%`;
+}
+
+export function formatCompact(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(2)}K`;
+  return formatUSD(value);
+}

--- a/lib/liquidity-utils.ts
+++ b/lib/liquidity-utils.ts
@@ -6,7 +6,8 @@ import JSBI from 'jsbi'; // v3-sdk utilities often return JSBI
 
 import { publicClient } from './viemClient'; 
 // Removed WETH_TOKEN, USDC_TOKEN from this import as they are not in swap-constants.ts
-import { TOKEN_DEFINITIONS, CHAIN_ID as DEFAULT_CHAIN_ID } from './swap-constants'; 
+import { CHAIN_ID as DEFAULT_CHAIN_ID } from './swap-constants';
+import { TOKEN_DEFINITIONS } from './pools-config'; 
 
 // --- Constants (Placeholders - replace with actual deployed addresses for your network) ---
 const POSITION_MANAGER_ADDRESS: Address = '0xPOSITION_MANAGER_ADDRESS_PLACEHOLDER'; 

--- a/lib/pools-config.ts
+++ b/lib/pools-config.ts
@@ -1,0 +1,162 @@
+import { getAddress, type Address } from 'viem';
+import { Token } from '@uniswap/sdk-core';
+import poolsConfig from '../config/pools.json';
+
+// Types based on pools.json structure
+export interface TokenConfig {
+  symbol: string;
+  name: string;
+  address: string;
+  decimals: number;
+  displayDecimals: number;
+  icon: string;
+}
+
+export interface PoolCurrency {
+  symbol: string;
+  address: string;
+}
+
+export interface PoolConfig {
+  id: string;
+  name: string;
+  description: string;
+  subgraphId: string;
+  currency0: PoolCurrency;
+  currency1: PoolCurrency;
+  fee: number;
+  tickSpacing: number;
+  hooks: string;
+  enabled: boolean;
+  featured: boolean;
+}
+
+export interface ContractsConfig {
+  poolManager: string;
+  quoter: string;
+  positionManager: string;
+  stateView: string;
+}
+
+// Utility functions
+export function getAllTokens(): Record<string, TokenConfig> {
+  return poolsConfig.tokens;
+}
+
+export function getToken(symbol: string): TokenConfig | null {
+  return poolsConfig.tokens[symbol as keyof typeof poolsConfig.tokens] || null;
+}
+
+export function getAllPools(): PoolConfig[] {
+  return poolsConfig.pools;
+}
+
+export function getEnabledPools(): PoolConfig[] {
+  return poolsConfig.pools.filter(pool => pool.enabled);
+}
+
+export function getFeaturedPools(): PoolConfig[] {
+  return poolsConfig.pools.filter(pool => pool.featured && pool.enabled);
+}
+
+export function getPoolByTokens(tokenA: string, tokenB: string): PoolConfig | null {
+  // Try both orders since pool currencies are ordered
+  const pool1 = poolsConfig.pools.find(pool => 
+    (pool.currency0.symbol === tokenA && pool.currency1.symbol === tokenB) ||
+    (pool.currency0.symbol === tokenB && pool.currency1.symbol === tokenA)
+  );
+  
+  return pool1 || null;
+}
+
+export function getPoolById(poolId: string): PoolConfig | null {
+  return poolsConfig.pools.find(pool => pool.id === poolId) || null;
+}
+
+// Create Token SDK instances
+export function createTokenSDK(tokenSymbol: string, chainId: number): Token | null {
+  const tokenConfig = getToken(tokenSymbol);
+  if (!tokenConfig) return null;
+  
+  return new Token(
+    chainId,
+    getAddress(tokenConfig.address),
+    tokenConfig.decimals,
+    tokenConfig.symbol
+  );
+}
+
+// Get pool configuration for two tokens
+export function getPoolConfigForTokens(fromToken: string, toToken: string) {
+  const pool = getPoolByTokens(fromToken, toToken);
+  if (!pool) return null;
+
+  const fromTokenConfig = getToken(fromToken);
+  const toTokenConfig = getToken(toToken);
+  
+  if (!fromTokenConfig || !toTokenConfig) return null;
+
+  return {
+    pool,
+    fromToken: fromTokenConfig,
+    toToken: toTokenConfig
+  };
+}
+
+// Helper to create pool key from pool config
+export function createPoolKeyFromConfig(pool: PoolConfig) {
+  return {
+    currency0: getAddress(pool.currency0.address),
+    currency1: getAddress(pool.currency1.address),
+    fee: pool.fee,
+    tickSpacing: pool.tickSpacing,
+    hooks: getAddress(pool.hooks)
+  };
+}
+
+// Get subgraph ID for a pool
+export function getPoolSubgraphId(poolId: string): string | null {
+  const pool = getPoolById(poolId);
+  return pool?.subgraphId || null;
+}
+
+// Get contract addresses
+export function getContracts(): ContractsConfig {
+  return poolsConfig.contracts;
+}
+
+export function getQuoterAddress(): Address {
+  return getAddress(poolsConfig.contracts.quoter);
+}
+
+export function getPositionManagerAddress(): Address {
+  return getAddress(poolsConfig.contracts.positionManager);
+}
+
+export function getStateViewAddress(): Address {
+  return getAddress(poolsConfig.contracts.stateView);
+}
+
+// Legacy compatibility - create TOKEN_DEFINITIONS from pools config
+export const TOKEN_DEFINITIONS: Record<string, {
+  addressRaw: string;
+  decimals: number;
+  symbol: string;
+  displayDecimals: number;
+}> = Object.fromEntries(
+  Object.entries(poolsConfig.tokens).map(([symbol, token]) => [
+    symbol,
+    {
+      addressRaw: token.address,
+      decimals: token.decimals,
+      symbol: token.symbol,
+      displayDecimals: token.displayDecimals
+    }
+  ])
+);
+
+export type TokenSymbol = keyof typeof TOKEN_DEFINITIONS;
+
+// Export chain info
+export const CHAIN_ID = poolsConfig.meta.chainId;
+export const CHAIN_NAME = poolsConfig.meta.chainName; 

--- a/lib/price-service.ts
+++ b/lib/price-service.ts
@@ -10,7 +10,8 @@ const COINGECKO_PRICE_ENDPOINT = 'https://api.coingecko.com/api/v3/simple/price'
 // Token IDs mapping (CoinGecko IDs)
 const TOKEN_COINGECKO_IDS = {
   'BTC': 'bitcoin',
-  'USDC': 'usd-coin'
+  'USDC': 'usd-coin',
+  'ETH': 'ethereum'
 };
 
 // Interface for price data
@@ -80,7 +81,8 @@ export async function getTokenPrice(tokenSymbol: string): Promise<number | null>
 export function getFallbackPrice(tokenSymbol: string): number {
   const fallbacks: Record<string, number> = {
     'BTC': 77000,
-    'USDC': 1
+    'USDC': 1,
+    'ETH': 3500
   };
   
   return fallbacks[tokenSymbol] || 0;

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,124 @@
+import { Redis } from '@upstash/redis'
+
+// Initialize Redis client (null if env vars missing)
+const redis = process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+  ? new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    })
+  : null
+
+interface CacheEntry<T> {
+  data: T
+  timestamp: number
+}
+
+interface WithCacheOptions<T> {
+  freshTTL?: number      // Seconds before data is considered stale (default: 300)
+  maxTTL?: number        // Seconds before data is evicted entirely (default: 900)
+  validate?: (data: T) => boolean  // Return false to reject and refetch
+}
+
+/**
+ * Cache wrapper with stale-while-revalidate pattern
+ *
+ * - HIT (fresh): Return cached data immediately
+ * - HIT (stale): Return cached data + trigger background refresh
+ * - MISS: Fetch from source, cache, return
+ *
+ * Falls back to direct fetch if Redis unavailable
+ */
+export async function withCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  options: WithCacheOptions<T> = {}
+): Promise<T> {
+  const { freshTTL = 300, maxTTL = 900, validate } = options
+
+  // No Redis = direct fetch
+  if (!redis) {
+    return fetcher()
+  }
+
+  try {
+    // Check cache
+    const cached = await redis.get<CacheEntry<T>>(key)
+
+    if (cached?.data !== undefined && cached?.timestamp) {
+      const ageSeconds = (Date.now() - cached.timestamp) / 1000
+
+      // Fresh hit - return immediately
+      if (ageSeconds < freshTTL) {
+        return cached.data
+      }
+
+      // Stale hit - return stale data, refresh in background
+      if (ageSeconds < maxTTL) {
+        refreshInBackground(key, fetcher, maxTTL, validate)
+        return cached.data
+      }
+    }
+
+    // Cache miss - fetch and cache
+    return await fetchAndCache(key, fetcher, maxTTL, validate)
+  } catch (error) {
+    console.error(`[Redis] Cache error for ${key}:`, error)
+    // Fallback to direct fetch on any Redis error
+    return fetcher()
+  }
+}
+
+async function fetchAndCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttl: number,
+  validate?: (data: T) => boolean
+): Promise<T> {
+  const data = await fetcher()
+
+  // Validate before caching
+  if (validate && !validate(data)) {
+    throw new Error(`Validation failed for cache key: ${key}`)
+  }
+
+  // Cache the result
+  if (redis) {
+    const entry: CacheEntry<T> = { data, timestamp: Date.now() }
+    await redis.setex(key, ttl, entry).catch(err => {
+      console.error(`[Redis] Failed to cache ${key}:`, err)
+    })
+  }
+
+  return data
+}
+
+function refreshInBackground<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttl: number,
+  validate?: (data: T) => boolean
+): void {
+  // Fire and forget - don't await
+  fetchAndCache(key, fetcher, ttl, validate).catch(err => {
+    console.error(`[Redis] Background refresh failed for ${key}:`, err)
+  })
+}
+
+/**
+ * Manually invalidate a cache key
+ */
+export async function invalidateCache(key: string): Promise<void> {
+  if (!redis) return
+  await redis.del(key).catch(err => {
+    console.error(`[Redis] Failed to invalidate ${key}:`, err)
+  })
+}
+
+/**
+ * Check if Redis is available
+ */
+export function isRedisAvailable(): boolean {
+  return redis !== null
+}
+
+export { redis }

--- a/lib/routing-engine.ts
+++ b/lib/routing-engine.ts
@@ -1,0 +1,247 @@
+import { getAllPools, getToken } from './pools-config';
+
+export interface SwapRoute {
+  path: string[]; // Array of token symbols in order [from, intermediate1, intermediate2, ..., to]
+  pools: PoolHop[]; // Array of pool information for each hop
+  hops: number; // Number of hops (pools.length)
+  isDirectRoute: boolean; // True if single hop, false if multi-hop
+}
+
+export interface PoolHop {
+  poolId: string;
+  poolName: string;
+  token0: string; // Token symbol
+  token1: string; // Token symbol
+  fee: number;
+  tickSpacing: number;
+  hooks: string;
+  subgraphId: string;
+}
+
+export interface RouteResult {
+  bestRoute: SwapRoute | null;
+  allRoutes: SwapRoute[];
+  hasDirectRoute: boolean;
+}
+
+/**
+ * Build a graph representation of all available pools for pathfinding
+ */
+function buildPoolGraph(): Map<string, PoolHop[]> {
+  const graph = new Map<string, PoolHop[]>();
+  const allPools = getAllPools();
+
+  // Initialize empty arrays for each token
+  const allTokens = new Set<string>();
+  Object.values(allPools).forEach(pool => {
+    allTokens.add(pool.currency0.symbol);
+    allTokens.add(pool.currency1.symbol);
+  });
+
+  allTokens.forEach(token => {
+    graph.set(token, []);
+  });
+
+  // Add pool connections to the graph
+  Object.values(allPools).forEach(pool => {
+    const poolHop: PoolHop = {
+      poolId: pool.id,
+      poolName: pool.name,
+      token0: pool.currency0.symbol,
+      token1: pool.currency1.symbol,
+      fee: pool.fee,
+      tickSpacing: pool.tickSpacing,
+      hooks: pool.hooks,
+      subgraphId: pool.subgraphId
+    };
+
+    // Add bidirectional connections
+    graph.get(pool.currency0.symbol)?.push(poolHop);
+    graph.get(pool.currency1.symbol)?.push(poolHop);
+  });
+
+  return graph;
+}
+
+/**
+ * Find all possible routes between two tokens using BFS with max depth
+ */
+function findAllRoutes(
+  fromToken: string, 
+  toToken: string, 
+  maxHops: number = 3
+): SwapRoute[] {
+  if (fromToken === toToken) {
+    return [];
+  }
+
+  const graph = buildPoolGraph();
+  const routes: SwapRoute[] = [];
+  
+  // BFS queue: [currentToken, path, usedPools, visitedTokens]
+  const queue: [string, string[], PoolHop[], Set<string>][] = [
+    [fromToken, [fromToken], [], new Set([fromToken])]
+  ];
+
+  while (queue.length > 0) {
+    const [currentToken, path, usedPools, visitedTokens] = queue.shift()!;
+    
+    // Skip if we've exceeded max hops
+    if (usedPools.length >= maxHops) {
+      continue;
+    }
+
+    const connections = graph.get(currentToken) || [];
+    
+    for (const poolHop of connections) {
+      // Determine the next token (the one that's not the current token)
+      const nextToken = poolHop.token0 === currentToken 
+        ? poolHop.token1 
+        : poolHop.token0;
+      
+      // Skip if we've already visited this token (prevent cycles)
+      if (visitedTokens.has(nextToken)) {
+        continue;
+      }
+
+      // Skip if we've already used this exact pool
+      if (usedPools.some(pool => pool.poolId === poolHop.poolId)) {
+        continue;
+      }
+
+      const newPath = [...path, nextToken];
+      const newUsedPools = [...usedPools, poolHop];
+      const newVisitedTokens = new Set([...visitedTokens, nextToken]);
+
+      // If we reached the target token, add this route
+      if (nextToken === toToken) {
+        routes.push({
+          path: newPath,
+          pools: newUsedPools,
+          hops: newUsedPools.length,
+          isDirectRoute: newUsedPools.length === 1
+        });
+      } else {
+        // Continue exploring from this token
+        queue.push([nextToken, newPath, newUsedPools, newVisitedTokens]);
+      }
+    }
+  }
+
+  return routes;
+}
+
+/**
+ * Score routes based on various factors (fewer hops is better, known pool reliability, etc.)
+ */
+function scoreRoute(route: SwapRoute): number {
+  let score = 0;
+
+  // Heavily favor direct routes
+  if (route.isDirectRoute) {
+    score += 1000;
+  }
+
+  // Penalty for each additional hop (exponential)
+  score -= Math.pow(route.hops, 2) * 100;
+
+  // Bonus for pools with tighter tick spacing (more precise)
+  route.pools.forEach(pool => {
+    if (pool.tickSpacing <= 1) score += 50;      // Very tight spacing
+    else if (pool.tickSpacing <= 10) score += 30; // Tight spacing  
+    else if (pool.tickSpacing <= 60) score += 10; // Normal spacing
+    // No bonus for wide spacing
+  });
+
+  // Bonus for stablecoin pairs (lower slippage typically)
+  const stablecoins = ['YUSDC', 'mUSDT'];
+  route.pools.forEach(pool => {
+    const isStablePair = stablecoins.includes(pool.token0) && stablecoins.includes(pool.token1);
+    if (isStablePair) score += 25;
+  });
+
+  return score;
+}
+
+/**
+ * Main function to find the best route between two tokens
+ */
+export function findBestRoute(fromToken: string, toToken: string): RouteResult {
+  console.log(`[RoutingEngine] Finding routes from ${fromToken} to ${toToken}`);
+  
+  // Validate tokens exist
+  const fromTokenConfig = getToken(fromToken);
+  const toTokenConfig = getToken(toToken);
+  
+  if (!fromTokenConfig || !toTokenConfig) {
+    console.error(`[RoutingEngine] Invalid tokens: ${fromToken} or ${toToken} not found`);
+    return {
+      bestRoute: null,
+      allRoutes: [],
+      hasDirectRoute: false
+    };
+  }
+
+  // Find all possible routes
+  const allRoutes = findAllRoutes(fromToken, toToken, 3); // Max 3 hops
+  
+  if (allRoutes.length === 0) {
+    console.warn(`[RoutingEngine] No routes found from ${fromToken} to ${toToken}`);
+    return {
+      bestRoute: null,
+      allRoutes: [],
+      hasDirectRoute: false
+    };
+  }
+
+  // Score and sort routes
+  const scoredRoutes = allRoutes.map(route => ({
+    route,
+    score: scoreRoute(route)
+  })).sort((a, b) => b.score - a.score); // Highest score first
+
+  const bestRoute = scoredRoutes[0].route;
+  const hasDirectRoute = allRoutes.some(route => route.isDirectRoute);
+
+  console.log(`[RoutingEngine] Found ${allRoutes.length} routes. Best route: ${bestRoute.path.join(' → ')} (${bestRoute.hops} hops)`);
+  
+  return {
+    bestRoute,
+    allRoutes,
+    hasDirectRoute
+  };
+}
+
+/**
+ * Get a direct route if one exists (for simple validation)
+ */
+export function getDirectRoute(fromToken: string, toToken: string): SwapRoute | null {
+  const result = findBestRoute(fromToken, toToken);
+  return result.hasDirectRoute ? result.allRoutes.find(route => route.isDirectRoute) || null : null;
+}
+
+/**
+ * Check if a direct route exists between two tokens
+ */
+export function hasDirectRoute(fromToken: string, toToken: string): boolean {
+  return getDirectRoute(fromToken, toToken) !== null;
+}
+
+/**
+ * Get all intermediate tokens in a route (excluding start and end)
+ */
+export function getIntermediateTokens(route: SwapRoute): string[] {
+  if (route.path.length <= 2) {
+    return []; // No intermediate tokens
+  }
+  return route.path.slice(1, -1); // Remove first and last
+}
+
+/**
+ * Convert route to readable string representation
+ */
+export function routeToString(route: SwapRoute): string {
+  const pathStr = route.path.join(' → ');
+  const hopStr = route.hops === 1 ? '1 hop' : `${route.hops} hops`;
+  return `${pathStr} (${hopStr})`;
+} 

--- a/lib/swap-constants.ts
+++ b/lib/swap-constants.ts
@@ -131,8 +131,12 @@ export const V4_POSITION_MANAGER_ABI = position_manager_abi;
 // --- V4 Quoter ABI ---
 // Based on Uniswap V4 documentation: https://docs.uniswap.org/contracts/v4/reference/periphery/lens/V4Quoter
 // QuoteExactSingleParams struct: { poolKey: { currency0, currency1, fee, tickSpacing, hooks }, zeroForOne, exactAmount, hookData }
+// QuoteExactParams struct: { currencyIn, path: PathKey[], amountIn }
+// PathKey struct: { intermediateCurrency, fee, tickSpacing, hooks, hookData }
 export const V4_QUOTER_ABI_STRINGS = [
   "function quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes)) external returns (uint256, uint256)",
-  "function quoteExactOutputSingle(((address,address,uint24,int24,address),bool,uint128,bytes)) external returns (uint256, uint256)"
+  "function quoteExactOutputSingle(((address,address,uint24,int24,address),bool,uint128,bytes)) external returns (uint256, uint256)",
+  "function quoteExactInput((address,(address,uint24,int24,address,bytes)[],uint128)) external returns (uint256, uint256)",
+  "function quoteExactOutput((address,(address,uint24,int24,address,bytes)[],uint128)) external returns (uint256, uint256)"
 ] as const;
 export const V4QuoterAbi: Abi = parseAbi(V4_QUOTER_ABI_STRINGS);

--- a/lib/swap-constants.ts
+++ b/lib/swap-constants.ts
@@ -120,6 +120,19 @@ export const getTargetChain = (rpcUrl: string) => ({
 export const V4_POSITION_MANAGER_ADDRESS_RAW = '0x4b2c77d209d3405f41a037ec6c77f7f5b8e2ca80'; // TODO: Replace with actual address
 export const V4_POSITION_MANAGER_ADDRESS: Address = getAddress(V4_POSITION_MANAGER_ADDRESS_RAW);
 
+// --- V4 Quoter Configuration ---
+export const V4_QUOTER_ADDRESS_RAW = '0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba'; // TODO: Replace with actual V4Quoter address
+export const V4_QUOTER_ADDRESS: Address = getAddress(V4_QUOTER_ADDRESS_RAW);
+
 // Empty bytes constant for hook data
 export const EMPTY_BYTES = '0x' as const;
 export const V4_POSITION_MANAGER_ABI = position_manager_abi;
+
+// --- V4 Quoter ABI ---
+// Based on Uniswap V4 documentation: https://docs.uniswap.org/contracts/v4/reference/periphery/lens/V4Quoter
+// QuoteExactSingleParams struct: { poolKey: { currency0, currency1, fee, tickSpacing, hooks }, zeroForOne, exactAmount, hookData }
+export const V4_QUOTER_ABI_STRINGS = [
+  "function quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes)) external returns (uint256, uint256)",
+  "function quoteExactOutputSingle(((address,address,uint24,int24,address),bool,uint128,bytes)) external returns (uint256, uint256)"
+] as const;
+export const V4QuoterAbi: Abi = parseAbi(V4_QUOTER_ABI_STRINGS);

--- a/pages/api/liquidity/check-token-approvals.ts
+++ b/pages/api/liquidity/check-token-approvals.ts
@@ -3,6 +3,7 @@ import { createPublicClient, http, getAddress, parseAbi } from 'viem';
 import { baseSepolia } from 'viem/chains';
 import { PERMIT2_ADDRESS, TOKEN_DEFINITIONS } from '@/lib/swap-constants';
 import { TokenSymbol } from '@/lib/swap-constants';
+import { TOKEN_DEFINITIONS as POOLS_TOKEN_DEFINITIONS } from '@/lib/pools-config';
 
 // Define constants from other files
 const POSITION_MANAGER_ADDRESS = getAddress("0x4b2c77d209d3405f41a037ec6c77f7f5b8e2ca80");
@@ -57,7 +58,7 @@ export default async function handler(
       });
     }
 
-    if (!TOKEN_DEFINITIONS[token0Symbol] || !TOKEN_DEFINITIONS[token1Symbol]) {
+    if (!POOLS_TOKEN_DEFINITIONS[token0Symbol] || !POOLS_TOKEN_DEFINITIONS[token1Symbol]) {
       return res.status(400).json({ 
         needsToken0Approval: true, 
         needsToken1Approval: true,
@@ -77,7 +78,7 @@ export default async function handler(
 
     // Check Token0 if needed
     if (parseFloat(amount0) > 0) {
-      const token0Address = TOKEN_DEFINITIONS[token0Symbol].addressRaw;
+      const token0Address = POOLS_TOKEN_DEFINITIONS[token0Symbol].addressRaw;
       
       // Step 1: Check ERC20 allowance from User to Permit2
       const eoaToPermit2Erc20Allowance = await publicClient.readContract({
@@ -87,7 +88,7 @@ export default async function handler(
         args: [getAddress(userAddress), PERMIT2_ADDRESS]
       }) as bigint;
 
-      const requiredAmount = parseFloat(amount0) * Math.pow(10, TOKEN_DEFINITIONS[token0Symbol].decimals);
+      const requiredAmount = parseFloat(amount0) * Math.pow(10, POOLS_TOKEN_DEFINITIONS[token0Symbol].decimals);
       const requiredAmountBigInt = BigInt(Math.floor(requiredAmount));
 
       if (eoaToPermit2Erc20Allowance >= requiredAmountBigInt) {
@@ -122,7 +123,7 @@ export default async function handler(
 
     // Check Token1 if needed
     if (parseFloat(amount1) > 0) {
-      const token1Address = TOKEN_DEFINITIONS[token1Symbol].addressRaw;
+      const token1Address = POOLS_TOKEN_DEFINITIONS[token1Symbol].addressRaw;
       
       // Step 1: Check ERC20 allowance from User to Permit2
       const eoaToPermit2Erc20Allowance = await publicClient.readContract({
@@ -132,7 +133,7 @@ export default async function handler(
         args: [getAddress(userAddress), PERMIT2_ADDRESS]
       }) as bigint;
 
-      const requiredAmount = parseFloat(amount1) * Math.pow(10, TOKEN_DEFINITIONS[token1Symbol].decimals);
+      const requiredAmount = parseFloat(amount1) * Math.pow(10, POOLS_TOKEN_DEFINITIONS[token1Symbol].decimals);
       const requiredAmountBigInt = BigInt(Math.floor(requiredAmount));
 
       if (eoaToPermit2Erc20Allowance >= requiredAmountBigInt) {

--- a/pages/api/liquidity/check-token-approvals.ts
+++ b/pages/api/liquidity/check-token-approvals.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createPublicClient, http, getAddress, parseAbi } from 'viem';
 import { baseSepolia } from 'viem/chains';
-import { PERMIT2_ADDRESS, TOKEN_DEFINITIONS } from '@/lib/swap-constants';
-import { TokenSymbol } from '@/lib/swap-constants';
-import { TOKEN_DEFINITIONS as POOLS_TOKEN_DEFINITIONS } from '@/lib/pools-config';
+import { PERMIT2_ADDRESS } from '@/lib/swap-constants';
+import { TOKEN_DEFINITIONS, TokenSymbol } from '@/lib/pools-config';
+import { getToken } from '@/lib/pools-config';
 
 // Define constants from other files
 const POSITION_MANAGER_ADDRESS = getAddress("0x4b2c77d209d3405f41a037ec6c77f7f5b8e2ca80");
@@ -58,7 +58,10 @@ export default async function handler(
       });
     }
 
-    if (!POOLS_TOKEN_DEFINITIONS[token0Symbol] || !POOLS_TOKEN_DEFINITIONS[token1Symbol]) {
+    const token0Config = getToken(token0Symbol);
+    const token1Config = getToken(token1Symbol);
+
+    if (!token0Config || !token1Config) {
       return res.status(400).json({ 
         needsToken0Approval: true, 
         needsToken1Approval: true,
@@ -78,42 +81,47 @@ export default async function handler(
 
     // Check Token0 if needed
     if (parseFloat(amount0) > 0) {
-      const token0Address = POOLS_TOKEN_DEFINITIONS[token0Symbol].addressRaw;
+      const token0Address = token0Config.address;
       
-      // Step 1: Check ERC20 allowance from User to Permit2
-      const eoaToPermit2Erc20Allowance = await publicClient.readContract({
-        address: getAddress(token0Address),
-        abi: parseAbi(['function allowance(address owner, address spender) external view returns (uint256)']),
-        functionName: 'allowance',
-        args: [getAddress(userAddress), PERMIT2_ADDRESS]
-      }) as bigint;
-
-      const requiredAmount = parseFloat(amount0) * Math.pow(10, POOLS_TOKEN_DEFINITIONS[token0Symbol].decimals);
-      const requiredAmountBigInt = BigInt(Math.floor(requiredAmount));
-
-      if (eoaToPermit2Erc20Allowance >= requiredAmountBigInt) {
-        // Step 2: Check Permit2 allowance for PositionManager
-        const permit2AllowanceTuple = await publicClient.readContract({
-          address: PERMIT2_ADDRESS,
-          abi: parseAbi(['function allowance(address owner, address token, address spender) external view returns (uint160 amount, uint48 expiration, uint48 nonce)']),
+      // Skip approval check for native ETH
+      if (token0Address === "0x0000000000000000000000000000000000000000") {
+        needsToken0Approval = false;
+      } else {
+        // Step 1: Check ERC20 allowance from User to Permit2
+        const eoaToPermit2Erc20Allowance = await publicClient.readContract({
+          address: getAddress(token0Address),
+          abi: parseAbi(['function allowance(address owner, address spender) external view returns (uint256)']),
           functionName: 'allowance',
-          args: [getAddress(userAddress), getAddress(token0Address), POSITION_MANAGER_ADDRESS]
-        }) as readonly [amount: bigint, expiration: number, nonce: number];
-        
-        const permit2SpenderAmount = permit2AllowanceTuple[0];
-        const permit2SpenderExpiration = permit2AllowanceTuple[1];
-        const currentTimestamp = Math.floor(Date.now() / 1000);
-        
-        // Check if the permit amount is sufficient and not expired
-        const sufficientAmount = requiredAmountBigInt > MAX_UINT_160 
-          ? permit2SpenderAmount >= MAX_UINT_160
-          : permit2SpenderAmount >= requiredAmountBigInt;
+          args: [getAddress(userAddress), PERMIT2_ADDRESS]
+        }) as bigint;
+
+        const requiredAmount = parseFloat(amount0) * Math.pow(10, token0Config.decimals);
+        const requiredAmountBigInt = BigInt(Math.floor(requiredAmount));
+
+        if (eoaToPermit2Erc20Allowance >= requiredAmountBigInt) {
+          // Step 2: Check Permit2 allowance for PositionManager
+          const permit2AllowanceTuple = await publicClient.readContract({
+            address: PERMIT2_ADDRESS,
+            abi: parseAbi(['function allowance(address owner, address token, address spender) external view returns (uint160 amount, uint48 expiration, uint48 nonce)']),
+            functionName: 'allowance',
+            args: [getAddress(userAddress), getAddress(token0Address), POSITION_MANAGER_ADDRESS]
+          }) as readonly [amount: bigint, expiration: number, nonce: number];
           
-        const notExpired = permit2SpenderExpiration === 0 || permit2SpenderExpiration > currentTimestamp;
-        
-        // Only set to false if both conditions are met
-        if (sufficientAmount && notExpired) {
-          needsToken0Approval = false;
+          const permit2SpenderAmount = permit2AllowanceTuple[0];
+          const permit2SpenderExpiration = permit2AllowanceTuple[1];
+          const currentTimestamp = Math.floor(Date.now() / 1000);
+          
+          // Check if the permit amount is sufficient and not expired
+          const sufficientAmount = requiredAmountBigInt > MAX_UINT_160 
+            ? permit2SpenderAmount >= MAX_UINT_160
+            : permit2SpenderAmount >= requiredAmountBigInt;
+            
+          const notExpired = permit2SpenderExpiration === 0 || permit2SpenderExpiration > currentTimestamp;
+          
+          // Only set to false if both conditions are met
+          if (sufficientAmount && notExpired) {
+            needsToken0Approval = false;
+          }
         }
       }
     } else {
@@ -123,42 +131,47 @@ export default async function handler(
 
     // Check Token1 if needed
     if (parseFloat(amount1) > 0) {
-      const token1Address = POOLS_TOKEN_DEFINITIONS[token1Symbol].addressRaw;
+      const token1Address = token1Config.address;
       
-      // Step 1: Check ERC20 allowance from User to Permit2
-      const eoaToPermit2Erc20Allowance = await publicClient.readContract({
-        address: getAddress(token1Address),
-        abi: parseAbi(['function allowance(address owner, address spender) external view returns (uint256)']),
-        functionName: 'allowance',
-        args: [getAddress(userAddress), PERMIT2_ADDRESS]
-      }) as bigint;
-
-      const requiredAmount = parseFloat(amount1) * Math.pow(10, POOLS_TOKEN_DEFINITIONS[token1Symbol].decimals);
-      const requiredAmountBigInt = BigInt(Math.floor(requiredAmount));
-
-      if (eoaToPermit2Erc20Allowance >= requiredAmountBigInt) {
-        // Step 2: Check Permit2 allowance for PositionManager
-        const permit2AllowanceTuple = await publicClient.readContract({
-          address: PERMIT2_ADDRESS,
-          abi: parseAbi(['function allowance(address owner, address token, address spender) external view returns (uint160 amount, uint48 expiration, uint48 nonce)']),
+      // Skip approval check for native ETH
+      if (token1Address === "0x0000000000000000000000000000000000000000") {
+        needsToken1Approval = false;
+      } else {
+        // Step 1: Check ERC20 allowance from User to Permit2
+        const eoaToPermit2Erc20Allowance = await publicClient.readContract({
+          address: getAddress(token1Address),
+          abi: parseAbi(['function allowance(address owner, address spender) external view returns (uint256)']),
           functionName: 'allowance',
-          args: [getAddress(userAddress), getAddress(token1Address), POSITION_MANAGER_ADDRESS]
-        }) as readonly [amount: bigint, expiration: number, nonce: number];
-        
-        const permit2SpenderAmount = permit2AllowanceTuple[0];
-        const permit2SpenderExpiration = permit2AllowanceTuple[1];
-        const currentTimestamp = Math.floor(Date.now() / 1000);
-        
-        // Check if the permit amount is sufficient and not expired
-        const sufficientAmount = requiredAmountBigInt > MAX_UINT_160 
-          ? permit2SpenderAmount >= MAX_UINT_160
-          : permit2SpenderAmount >= requiredAmountBigInt;
+          args: [getAddress(userAddress), PERMIT2_ADDRESS]
+        }) as bigint;
+
+        const requiredAmount = parseFloat(amount1) * Math.pow(10, token1Config.decimals);
+        const requiredAmountBigInt = BigInt(Math.floor(requiredAmount));
+
+        if (eoaToPermit2Erc20Allowance >= requiredAmountBigInt) {
+          // Step 2: Check Permit2 allowance for PositionManager
+          const permit2AllowanceTuple = await publicClient.readContract({
+            address: PERMIT2_ADDRESS,
+            abi: parseAbi(['function allowance(address owner, address token, address spender) external view returns (uint160 amount, uint48 expiration, uint48 nonce)']),
+            functionName: 'allowance',
+            args: [getAddress(userAddress), getAddress(token1Address), POSITION_MANAGER_ADDRESS]
+          }) as readonly [amount: bigint, expiration: number, nonce: number];
           
-        const notExpired = permit2SpenderExpiration === 0 || permit2SpenderExpiration > currentTimestamp;
-        
-        // Only set to false if both conditions are met
-        if (sufficientAmount && notExpired) {
-          needsToken1Approval = false;
+          const permit2SpenderAmount = permit2AllowanceTuple[0];
+          const permit2SpenderExpiration = permit2AllowanceTuple[1];
+          const currentTimestamp = Math.floor(Date.now() / 1000);
+          
+          // Check if the permit amount is sufficient and not expired
+          const sufficientAmount = requiredAmountBigInt > MAX_UINT_160 
+            ? permit2SpenderAmount >= MAX_UINT_160
+            : permit2SpenderAmount >= requiredAmountBigInt;
+            
+          const notExpired = permit2SpenderExpiration === 0 || permit2SpenderExpiration > currentTimestamp;
+          
+          // Only set to false if both conditions are met
+          if (sufficientAmount && notExpired) {
+            needsToken1Approval = false;
+          }
         }
       }
     } else {

--- a/pages/api/liquidity/get-pool-params.ts
+++ b/pages/api/liquidity/get-pool-params.ts
@@ -1,0 +1,130 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAddress, parseAbi, type Hex } from "viem";
+import { publicClient } from "../../../lib/viemClient";
+
+const STATE_VIEW_ADDRESS = getAddress("0x571291b572ed32ce6751a2cb2486ebee8defb9b4");
+
+interface GetPoolParamsRequest extends NextApiRequest {
+    query: {
+        poolId: string;
+    };
+}
+
+interface GetPoolParamsResponse {
+    poolId: string;
+    sqrtPriceX96: string;
+    tick: number;
+    protocolFee: number;
+    lpFee: number;
+    isInitialized: boolean;
+    message: string;
+}
+
+export default async function handler(
+    req: GetPoolParamsRequest,
+    res: NextApiResponse<GetPoolParamsResponse>
+) {
+    if (req.method !== 'GET') {
+        res.setHeader('Allow', ['GET']);
+        return res.status(405).json({ 
+            message: `Method ${req.method} Not Allowed`,
+            poolId: '',
+            sqrtPriceX96: '0',
+            tick: 0,
+            protocolFee: 0,
+            lpFee: 0,
+            isInitialized: false
+        });
+    }
+
+    try {
+        const { poolId } = req.query;
+
+        if (!poolId || typeof poolId !== 'string') {
+            return res.status(400).json({ 
+                message: "Pool ID is required",
+                poolId: '',
+                sqrtPriceX96: '0',
+                tick: 0,
+                protocolFee: 0,
+                lpFee: 0,
+                isInitialized: false
+            });
+        }
+
+        console.log(`[POOL PARAMS] Querying parameters for pool: ${poolId}`);
+
+        // Query pool slot0 data to get current state
+        const stateViewAbi = parseAbi([
+            'function getSlot0(bytes32 poolId) external view returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)'
+        ]);
+
+        try {
+            const slot0Data = await publicClient.readContract({
+                address: STATE_VIEW_ADDRESS,
+                abi: stateViewAbi,
+                functionName: 'getSlot0',
+                args: [poolId as Hex]
+            }) as readonly [bigint, number, number, number];
+
+            const [sqrtPriceX96, tick, protocolFee, lpFee] = slot0Data;
+            
+            const isInitialized = sqrtPriceX96 > 0n;
+            
+            console.log(`[POOL PARAMS] Pool ${poolId} parameters:`);
+            console.log(`[POOL PARAMS] - sqrtPriceX96: ${sqrtPriceX96.toString()}`);
+            console.log(`[POOL PARAMS] - tick: ${tick}`);
+            console.log(`[POOL PARAMS] - protocolFee: ${protocolFee}`);
+            console.log(`[POOL PARAMS] - lpFee: ${lpFee}`);
+            console.log(`[POOL PARAMS] - isInitialized: ${isInitialized}`);
+
+            // Note: Tick spacing is not directly available from slot0
+            // It's encoded in the pool key when the pool was created
+            // Common V4 tick spacings: 1, 10, 60, 200
+            
+            let inferredTickSpacing = "unknown";
+            if (tick % 200 === 0) inferredTickSpacing = "200 (likely)";
+            else if (tick % 60 === 0) inferredTickSpacing = "60 (likely)";
+            else if (tick % 10 === 0) inferredTickSpacing = "10 (likely)";
+            else if (tick % 1 === 0) inferredTickSpacing = "1 (likely)";
+
+            const message = isInitialized 
+                ? `Pool is initialized. Inferred tick spacing: ${inferredTickSpacing}`
+                : `Pool exists but is not initialized (sqrtPriceX96 = 0)`;
+
+            return res.status(200).json({
+                poolId,
+                sqrtPriceX96: sqrtPriceX96.toString(),
+                tick,
+                protocolFee,
+                lpFee,
+                isInitialized,
+                message
+            });
+
+        } catch (error) {
+            console.error(`[POOL PARAMS] Error querying pool ${poolId}:`, error);
+            return res.status(500).json({
+                message: `Error querying pool: ${error}`,
+                poolId,
+                sqrtPriceX96: '0',
+                tick: 0,
+                protocolFee: 0,
+                lpFee: 0,
+                isInitialized: false
+            });
+        }
+
+    } catch (error: any) {
+        console.error("[API get-pool-params] Error:", error);
+        return res.status(500).json({ 
+            message: error.message || "An unknown error occurred.",
+            poolId: '',
+            sqrtPriceX96: '0',
+            tick: 0,
+            protocolFee: 0,
+            lpFee: 0,
+            isInitialized: false
+        });
+    }
+} 

--- a/pages/api/liquidity/get-pool-state.ts
+++ b/pages/api/liquidity/get-pool-state.ts
@@ -4,8 +4,7 @@ import JSBI from 'jsbi';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { STATE_VIEW_ABI as STATE_VIEW_HUMAN_READABLE_ABI } from "../../../lib/abis/state_view_abi";
-import { TOKEN_DEFINITIONS, TokenSymbol } from "../../../lib/swap-constants";
-import { TOKEN_DEFINITIONS as POOLS_TOKEN_DEFINITIONS } from "../../../lib/pools-config";
+import { getToken, TokenSymbol, getStateViewAddress } from "../../../lib/pools-config";
 import { publicClient } from "../../../lib/viemClient";
 import {
     isAddress,
@@ -14,11 +13,8 @@ import {
     type Hex
 } from "viem";
 
-// Contract addresses & constants
-const STATE_VIEW_ADDRESS = getAddress("0x571291b572ed32ce6751a2cb2486ebee8defb9b4"); // Ensure this is correct
-const DEFAULT_HOOK_ADDRESS = getAddress("0x94ba380a340E020Dc29D7883f01628caBC975000"); // Ensure this is correct
-const DEFAULT_FEE = 8388608; // Uniswap V4 default pool fee
-const DEFAULT_TICK_SPACING = 60; // Uniswap V4 default tick spacing
+// Contract addresses from pools config
+const STATE_VIEW_ADDRESS = getStateViewAddress();
 
 interface GetPoolStateRequest extends NextApiRequest {
     body: {
@@ -119,17 +115,17 @@ export default async function handler(
         } = req.body;
 
         // --- Input Validation ---
-        if (!POOLS_TOKEN_DEFINITIONS[token0Symbol] || !POOLS_TOKEN_DEFINITIONS[token1Symbol]) {
+        const token0Config = getToken(token0Symbol);
+        const token1Config = getToken(token1Symbol);
+
+        if (!token0Config || !token1Config) {
             return res.status(400).json({ message: "Invalid token symbol(s) provided." });
         }
         // TODO: Add validation for chainId
 
-        const token0Config = POOLS_TOKEN_DEFINITIONS[token0Symbol];
-        const token1Config = POOLS_TOKEN_DEFINITIONS[token1Symbol];
-
         // --- SDK Token Objects (using original symbols from request) ---
-        const sdkToken0Req = new Token(chainId, getAddress(token0Config.addressRaw), token0Config.decimals, token0Config.symbol);
-        const sdkToken1Req = new Token(chainId, getAddress(token1Config.addressRaw), token1Config.decimals, token1Config.symbol);
+        const sdkToken0Req = new Token(chainId, getAddress(token0Config.address), token0Config.decimals, token0Config.symbol);
+        const sdkToken1Req = new Token(chainId, getAddress(token1Config.address), token1Config.decimals, token1Config.symbol);
 
         // --- Token Sorting (Crucial for V4 SDK pool key) ---
         const [sortedSdkToken0, sortedSdkToken1] = sdkToken0Req.sortsBefore(sdkToken1Req)

--- a/pages/api/liquidity/get-positions.ts
+++ b/pages/api/liquidity/get-positions.ts
@@ -7,6 +7,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { STATE_VIEW_ABI as STATE_VIEW_HUMAN_READABLE_ABI } from "../../../lib/abis/state_view_abi"; // Adjusted path
 import { publicClient } from "../../../lib/viemClient"; // Import publicClient
 import { getAddress, parseAbi, type Address, type Abi } from "viem"; // Import getAddress and parseAbi, and added Abi for type cast
+import { getTokenSymbolByAddress, getAllPools, getStateViewAddress, CHAIN_ID } from "../../../lib/pools-config"; // Import the mapping utility
 
 // Load environment variables - ensure .env is at the root or configure path
 // dotenv.config({ path: '.env.local' }); // Removed: Next.js handles .env.local automatically
@@ -14,11 +15,8 @@ import { getAddress, parseAbi, type Address, type Abi } from "viem"; // Import g
 // Constants
 const SUBGRAPH_URL = "https://api.studio.thegraph.com/query/111443/alphix-v-4/version/latest";
 // const RPC_URL = process.env.RPC_URL; // No longer directly used here
-const STATE_VIEW_ADDRESS = getAddress("0x571291b572ed32ce6751a2cb2486ebee8defb9b4"); // Use getAddress for checksum
-const DEFAULT_FEE = 8388608;
-const DEFAULT_TICK_SPACING = 60;
-const DEFAULT_HOOK_ADDRESS = "0x94ba380a340E020Dc29D7883f01628caBC975000";
-const DEFAULT_CHAIN_ID = 84532; // Base Sepolia
+const STATE_VIEW_ADDRESS = getStateViewAddress();
+const DEFAULT_CHAIN_ID = CHAIN_ID;
 
 // --- Interfaces for Subgraph Response ---
 interface SubgraphToken {
@@ -95,6 +93,21 @@ const GET_USER_POSITIONS_QUERY = `
   }
 `;
 
+// Create pool mapping from pools.json for dynamic lookup
+function createPoolTickSpacingMap(): { [poolId: string]: number } {
+    const pools = getAllPools();
+    const mapping: { [poolId: string]: number } = {};
+    
+    pools.forEach(pool => {
+        if (pool.subgraphId) {
+            mapping[pool.subgraphId.toLowerCase()] = pool.tickSpacing;
+        }
+    });
+    
+    console.log("Created pool tick spacing mapping:", mapping);
+    return mapping;
+}
+
 async function fetchAndProcessUserPositionsForApi(ownerAddress: string): Promise<ProcessedPosition[]> {
     // Removed the explicit RPC_URL check here, as publicClient handles its own RPC configuration, including defaults.
     // if (!process.env.RPC_URL && !process.env.NEXT_PUBLIC_RPC_URL) { 
@@ -143,6 +156,9 @@ async function fetchAndProcessUserPositionsForApi(ownerAddress: string): Promise
 
     const processedPositions: ProcessedPosition[] = [];
     const poolStatesCache = new Map<string, { sqrtPriceX96: string; tick: number }>();
+    
+    // Get pool tick spacing mapping from pools.json
+    const poolTickSpacingMap = createPoolTickSpacingMap();
 
     for (const rawPos of rawPositions) {
         try {
@@ -197,22 +213,76 @@ async function fetchAndProcessUserPositionsForApi(ownerAddress: string): Promise
                 }
             }
 
+            // Get the correct tick spacing for this pool
+            let v4PoolTickSpacing = poolTickSpacingMap[poolId.toLowerCase()];
+            
+            // Find the pool configuration to get fee and hooks
+            const pools = getAllPools();
+            const poolConfig = pools.find(p => p.subgraphId?.toLowerCase() === poolId.toLowerCase());
+            
+            if (!poolConfig) {
+                console.warn(`API: No pool configuration found for pool ${poolId}, skipping position ${rawPos.id}`);
+                continue;
+            }
+            
+            if (!v4PoolTickSpacing) {
+                console.warn(`API: No tick spacing found for pool ${poolId}, skipping position ${rawPos.id}`);
+                continue;
+            }
+
             const v4Pool = new V4Pool(
                 sdkToken0,
                 sdkToken1,
-                            DEFAULT_FEE, // Assuming fee is constant from PoolKey, might need to fetch if dynamic
-            DEFAULT_TICK_SPACING, // Assuming tickSpacing is constant
-                rawPos.hook || DEFAULT_HOOK_ADDRESS, // Use hook from position or default
+                poolConfig.fee, // Use fee from pool configuration
+                v4PoolTickSpacing, // Use the correct tick spacing for this pool
+                rawPos.hook || poolConfig.hooks, // Use hook from position or pool config
                 slot0.sqrtPriceX96,
                 JSBI.BigInt(0), // Liquidity (not strictly needed for position.amount0/1 calc from existing liquidity)
                 slot0.tick
             );
 
+            // Validate tick values before creating V4Position
+            const tickLower = Number(rawPos.tickLower);
+            const tickUpper = Number(rawPos.tickUpper);
+            
+            console.log(`API: Processing position ${rawPos.id} with tickLower=${tickLower}, tickUpper=${tickUpper}, liquidity=${rawPos.liquidity}`);
+            
+            // Check for valid tick range
+            if (tickLower >= tickUpper) {
+                console.warn(`API: Skipping position ${rawPos.id} with invalid tick range: tickLower=${tickLower} >= tickUpper=${tickUpper}`);
+                continue;
+            }
+            
+            // Check for extreme tick values (V4 has limits around ±887272)
+            const MAX_TICK = 887270; // Slightly below the actual max to be safe
+            const MIN_TICK = -887270;
+            if (tickLower < MIN_TICK || tickUpper > MAX_TICK) {
+                console.warn(`API: Skipping position ${rawPos.id} with ticks outside valid range: tickLower=${tickLower}, tickUpper=${tickUpper}`);
+                continue;
+            }
+            
+            // Check for zero liquidity positions (closed positions)
+            const liquidityBigInt = JSBI.BigInt(rawPos.liquidity);
+            if (JSBI.equal(liquidityBigInt, JSBI.BigInt(0))) {
+                console.warn(`API: Skipping position ${rawPos.id} with zero liquidity (closed position)`);
+                continue;
+            }
+            
+            // Check tick spacing alignment - this is crucial for V4
+            if (tickLower % v4PoolTickSpacing !== 0) {
+                console.warn(`API: Skipping position ${rawPos.id} with tickLower ${tickLower} not aligned to tick spacing ${v4PoolTickSpacing}`);
+                continue;
+            }
+            if (tickUpper % v4PoolTickSpacing !== 0) {
+                console.warn(`API: Skipping position ${rawPos.id} with tickUpper ${tickUpper} not aligned to tick spacing ${v4PoolTickSpacing}`);
+                continue;
+            }
+
             const v4Position = new V4Position({
                 pool: v4Pool,
-                tickLower: Number(rawPos.tickLower),
-                tickUpper: Number(rawPos.tickUpper),
-                liquidity: JSBI.BigInt(rawPos.liquidity)
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidity: liquidityBigInt
             });
 
             const rawAmount0 = v4Position.amount0.quotient.toString();
@@ -229,13 +299,13 @@ async function fetchAndProcessUserPositionsForApi(ownerAddress: string): Promise
                 poolId: poolId,
                 token0: {
                     address: sdkToken0.address,
-                    symbol: sdkToken0.symbol || 'N/A',
+                    symbol: getTokenSymbolByAddress(sdkToken0.address) || sdkToken0.symbol || 'N/A',
                     amount: formattedAmount0,
                     rawAmount: rawAmount0,
                 },
                 token1: {
                     address: sdkToken1.address,
-                    symbol: sdkToken1.symbol || 'N/A',
+                    symbol: getTokenSymbolByAddress(sdkToken1.address) || sdkToken1.symbol || 'N/A',
                     amount: formattedAmount1,
                     rawAmount: rawAmount1,
                 },

--- a/pages/api/liquidity/get-positions.ts
+++ b/pages/api/liquidity/get-positions.ts
@@ -200,8 +200,8 @@ async function fetchAndProcessUserPositionsForApi(ownerAddress: string): Promise
             const v4Pool = new V4Pool(
                 sdkToken0,
                 sdkToken1,
-                DEFAULT_FEE, // Assuming fee is constant from PoolKey, might need to fetch if dynamic
-                DEFAULT_TICK_SPACING, // Assuming tickSpacing is constant
+                            DEFAULT_FEE, // Assuming fee is constant from PoolKey, might need to fetch if dynamic
+            DEFAULT_TICK_SPACING, // Assuming tickSpacing is constant
                 rawPos.hook || DEFAULT_HOOK_ADDRESS, // Use hook from position or default
                 slot0.sqrtPriceX96,
                 JSBI.BigInt(0), // Liquidity (not strictly needed for position.amount0/1 calc from existing liquidity)

--- a/pages/api/liquidity/get-rolling-volume-fees.ts
+++ b/pages/api/liquidity/get-rolling-volume-fees.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getPoolSubgraphId } from '../../../lib/pools-config';
 
 // Use the subgraph URL from get-positions.ts
 const SUBGRAPH_URL = "https://api.studio.thegraph.com/query/111443/alphix-v-4/version/latest";
@@ -48,15 +49,18 @@ async function fetchRollingVolumeAndFeesForApi(
     poolId: string,
     days: number
 ): Promise<RollingVolumeAndFees> {
+    // Convert friendly pool ID to subgraph ID
+    const subgraphId = getPoolSubgraphId(poolId) || poolId;
+    
     const nowInSeconds = Math.floor(Date.now() / 1000);
     const cutoffTimestampInSeconds = nowInSeconds - (days * 24 * 60 * 60);
 
     const variables = {
-        poolId: poolId.toLowerCase(), // Ensure poolId is lowercase for subgraph
+        poolId: subgraphId.toLowerCase(), // Ensure poolId is lowercase for subgraph
         cutoffTimestamp: BigInt(cutoffTimestampInSeconds).toString(), // Use BigInt constructor and convert to string
     };
 
-    console.log(`API: Fetching ${days}d volume/fees for pool: ${poolId}`);
+    console.log(`API: Fetching ${days}d volume/fees for pool: ${poolId} (subgraph ID: ${subgraphId})`);
 
     const response = await fetch(SUBGRAPH_URL, {
         method: 'POST',

--- a/pages/api/liquidity/initialize-pool.ts
+++ b/pages/api/liquidity/initialize-pool.ts
@@ -1,0 +1,109 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAddress, parseAbi, type Hex } from "viem";
+import { TOKEN_DEFINITIONS as POOLS_TOKEN_DEFINITIONS, getPoolByTokens } from "../../../lib/pools-config";
+import { TokenSymbol } from "../../../lib/swap-constants";
+import { publicClient } from "../../../lib/viemClient";
+import { Token } from '@uniswap/sdk-core';
+import { Pool as V4Pool } from "@uniswap/v4-sdk";
+import JSBI from 'jsbi';
+
+const POOL_MANAGER_ADDRESS = getAddress("0x0000000000000000000000000000000000000000"); // Replace with actual PoolManager address
+const STATE_VIEW_ADDRESS = getAddress("0x571291b572ed32ce6751a2cb2486ebee8defb9b4");
+
+interface InitializePoolRequest extends NextApiRequest {
+    body: {
+        token0Symbol: TokenSymbol;
+        token1Symbol: TokenSymbol;
+        chainId: number;
+    };
+}
+
+interface InitializePoolResponse {
+    isInitialized: boolean;
+    needsInitialization?: boolean;
+    message: string;
+    poolId?: string;
+    initializeTransaction?: {
+        to: string;
+        data: string;
+        value: string;
+    };
+}
+
+export default async function handler(
+    req: InitializePoolRequest,
+    res: NextApiResponse<InitializePoolResponse>
+) {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', ['POST']);
+        return res.status(405).json({ message: `Method ${req.method} Not Allowed`, isInitialized: false });
+    }
+
+    try {
+        const { token0Symbol, token1Symbol, chainId } = req.body;
+
+        if (!POOLS_TOKEN_DEFINITIONS[token0Symbol] || !POOLS_TOKEN_DEFINITIONS[token1Symbol]) {
+            return res.status(400).json({ message: "Invalid token symbol(s) provided.", isInitialized: false });
+        }
+
+        const poolConfig = getPoolByTokens(token0Symbol, token1Symbol);
+        if (!poolConfig) {
+            return res.status(400).json({ message: `No pool configuration found for ${token0Symbol}/${token1Symbol}`, isInitialized: false });
+        }
+
+        const poolId = poolConfig.subgraphId;
+        console.log(`[POOL INIT] Checking initialization status for pool: ${poolId}`);
+
+        // Check if pool is initialized by trying to get slot0 data
+        const stateViewAbi = parseAbi([
+            'function getSlot0(bytes32 poolId) external view returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)'
+        ]);
+
+        try {
+            const slot0Data = await publicClient.readContract({
+                address: STATE_VIEW_ADDRESS,
+                abi: stateViewAbi,
+                functionName: 'getSlot0',
+                args: [poolId as Hex]
+            }) as readonly [bigint, number, number, number];
+
+            const sqrtPriceX96 = slot0Data[0];
+            
+            if (sqrtPriceX96 > 0n) {
+                console.log(`[POOL INIT] Pool ${poolId} is already initialized with sqrtPriceX96: ${sqrtPriceX96.toString()}`);
+                return res.status(200).json({
+                    isInitialized: true,
+                    message: `Pool ${token0Symbol}/${token1Symbol} is already initialized`,
+                    poolId
+                });
+            } else {
+                console.log(`[POOL INIT] Pool ${poolId} exists but sqrtPriceX96 is 0 - needs initialization`);
+                
+                // Calculate initial price (1:1 for stablecoins, or market price)
+                const initialSqrtPriceX96 = "79228162514264337593543950336"; // sqrt(1) * 2^96 for 1:1 price
+                
+                return res.status(200).json({
+                    isInitialized: false,
+                    needsInitialization: true,
+                    message: `Pool ${token0Symbol}/${token1Symbol} needs to be initialized. Please use Uniswap V4 PoolManager to initialize with sqrtPriceX96: ${initialSqrtPriceX96}`,
+                    poolId
+                });
+            }
+        } catch (error) {
+            console.error(`[POOL INIT] Error checking pool ${poolId}:`, error);
+            return res.status(200).json({
+                isInitialized: false,
+                needsInitialization: true,
+                message: `Pool ${token0Symbol}/${token1Symbol} may not exist or needs initialization. Error: ${error}`,
+                poolId
+            });
+        }
+
+    } catch (error: any) {
+        console.error("[API initialize-pool] Error:", error);
+        return res.status(500).json({ 
+            message: error.message || "An unknown error occurred.", 
+            isInitialized: false 
+        });
+    }
+} 

--- a/pages/api/liquidity/initialize-pool.ts
+++ b/pages/api/liquidity/initialize-pool.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAddress, parseAbi, type Hex } from "viem";
-import { TOKEN_DEFINITIONS as POOLS_TOKEN_DEFINITIONS, getPoolByTokens } from "../../../lib/pools-config";
+import { getToken, getPoolByTokens } from "../../../lib/pools-config";
 import { TokenSymbol } from "../../../lib/swap-constants";
 import { publicClient } from "../../../lib/viemClient";
 import { Token } from '@uniswap/sdk-core';
@@ -42,7 +42,10 @@ export default async function handler(
     try {
         const { token0Symbol, token1Symbol, chainId } = req.body;
 
-        if (!POOLS_TOKEN_DEFINITIONS[token0Symbol] || !POOLS_TOKEN_DEFINITIONS[token1Symbol]) {
+        const token0Config = getToken(token0Symbol);
+        const token1Config = getToken(token1Symbol);
+
+        if (!token0Config || !token1Config) {
             return res.status(400).json({ message: "Invalid token symbol(s) provided.", isInitialized: false });
         }
 

--- a/pages/api/liquidity/pool-metrics.ts
+++ b/pages/api/liquidity/pool-metrics.ts
@@ -1,0 +1,102 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getPoolSubgraphId } from '@/lib/pools-config'
+import { withCache } from '@/lib/redis'
+import { cacheKeys, cacheTTL } from '@/lib/cache-keys'
+
+const SUBGRAPH_URL = "https://api.studio.thegraph.com/query/111443/alphix-v-4/version/latest"
+
+interface PoolMetrics {
+  totalFeesToken0: number
+  avgTVLToken0: number
+  days: number
+}
+
+const POOL_METRICS_QUERY = `
+  query PoolMetrics($poolId: String!, $days: Int!) {
+    pool(id: $poolId) {
+      id
+      totalValueLockedToken0
+      totalValueLockedToken1
+    }
+    poolDayDatas(
+      where: { pool: $poolId }
+      first: $days
+      orderBy: date
+      orderDirection: desc
+    ) {
+      date
+      volumeToken0
+      feesToken0
+      tvlUSD
+    }
+  }
+`
+
+async function fetchPoolMetrics(poolId: string, days: number = 7): Promise<PoolMetrics> {
+  const res = await fetch(SUBGRAPH_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: POOL_METRICS_QUERY,
+      variables: { poolId: poolId.toLowerCase(), days }
+    })
+  })
+
+  if (!res.ok) {
+    throw new Error(`Subgraph error: ${res.status}`)
+  }
+
+  const result = await res.json()
+  const pool = result.data?.pool
+  const dayDatas = result.data?.poolDayDatas || []
+
+  if (!pool || dayDatas.length === 0) {
+    return { totalFeesToken0: 0, avgTVLToken0: 0, days: 0 }
+  }
+
+  // Sum fees from day data
+  const totalFeesToken0 = dayDatas.reduce(
+    (sum: number, day: { feesToken0?: string }) => sum + parseFloat(day.feesToken0 || '0'),
+    0
+  )
+
+  // Use current TVL from pool
+  const avgTVLToken0 = parseFloat(pool.totalValueLockedToken0 || '0')
+
+  return {
+    totalFeesToken0,
+    avgTVLToken0,
+    days: dayDatas.length
+  }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { poolId } = req.query
+
+  if (!poolId || typeof poolId !== 'string') {
+    return res.status(400).json({ error: 'poolId required' })
+  }
+
+  try {
+    const subgraphId = getPoolSubgraphId(poolId) || poolId
+
+    const metrics = await withCache(
+      cacheKeys.poolMetrics(subgraphId),
+      () => fetchPoolMetrics(subgraphId),
+      {
+        freshTTL: cacheTTL.poolMetrics.fresh,
+        maxTTL: cacheTTL.poolMetrics.max
+      }
+    )
+
+    res.setHeader('Cache-Control', 's-maxage=3600, stale-while-revalidate=600')
+    return res.status(200).json(metrics)
+  } catch (error) {
+    console.error('[pool-metrics] Error:', error)
+    return res.status(500).json({ error: 'Failed to fetch pool metrics' })
+  }
+}

--- a/pages/api/prices/get-token-prices.ts
+++ b/pages/api/prices/get-token-prices.ts
@@ -14,9 +14,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Get USDC price
     const usdcPrice = await getTokenPrice('USDC') || getFallbackPrice('USDC');
     
+    // Get ETH price
+    const ethPrice = await getTokenPrice('ETH') || getFallbackPrice('ETH');
+    
     return res.status(200).json({
       BTC: btcPrice,
       USDC: usdcPrice,
+      ETH: ethPrice,
       timestamp: Date.now()
     });
   } catch (error: any) {

--- a/pages/api/swap/get-quote.ts
+++ b/pages/api/swap/get-quote.ts
@@ -1,5 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { TOKEN_DEFINITIONS, TokenSymbol } from '../../../lib/swap-constants';
+import { getAddress, parseUnits, type Address } from 'viem';
+import { Token } from '@uniswap/sdk-core';
+import { 
+  TokenSymbol, 
+  getPoolConfigForTokens,
+  createTokenSDK,
+  createPoolKeyFromConfig,
+  getQuoterAddress,
+  CHAIN_ID
+} from '../../../lib/pools-config';
+import { V4QuoterAbi, EMPTY_BYTES } from '../../../lib/swap-constants';
+import { publicClient } from '../../../lib/viemClient';
 
 interface GetQuoteRequest extends NextApiRequest {
   body: {
@@ -8,6 +19,57 @@ interface GetQuoteRequest extends NextApiRequest {
     amountDecimalsStr: string;
     chainId: number;
     debug?: boolean;
+  };
+}
+
+// Helper function to create pool key and determine swap direction
+function createPoolKeyAndDirection(fromToken: Token, toToken: Token, poolConfig: any) {
+  // Determine token order (same as build-tx.ts)
+  const token0 = fromToken.sortsBefore(toToken) ? fromToken : toToken;
+  const token1 = fromToken.sortsBefore(toToken) ? toToken : fromToken;
+  
+  const poolKey = createPoolKeyFromConfig(poolConfig.pool);
+  
+  // zeroForOne is true if swapping from currency0 to currency1
+  const zeroForOne = fromToken.sortsBefore(toToken);
+  
+  return { poolKey, zeroForOne };
+}
+
+// Helper function to call V4Quoter for exact input
+async function getV4QuoteExactInput(
+  fromToken: Token,
+  toToken: Token,
+  amountInSmallestUnits: bigint,
+  poolConfig: any
+): Promise<{ amountOut: bigint; gasEstimate: bigint }> {
+  const { poolKey, zeroForOne } = createPoolKeyAndDirection(fromToken, toToken, poolConfig);
+  
+  console.log(`[V4 Quoter] Calling quoteExactInputSingle:`, {
+    poolKey,
+    zeroForOne,
+    exactAmount: amountInSmallestUnits.toString(),
+    hookData: EMPTY_BYTES
+  });
+  
+  // Structure the parameters as QuoteExactSingleParams struct
+  const quoteParams = [
+    [poolKey.currency0, poolKey.currency1, poolKey.fee, poolKey.tickSpacing, poolKey.hooks], // poolKey struct
+    zeroForOne,
+    amountInSmallestUnits,
+    EMPTY_BYTES
+  ] as const;
+
+  const result = await publicClient.readContract({
+    address: getQuoterAddress(),
+    abi: V4QuoterAbi,
+    functionName: 'quoteExactInputSingle',
+    args: [quoteParams]
+  }) as [bigint, bigint]; // [amountOut, gasEstimate]
+  
+  return {
+    amountOut: result[0],
+    gasEstimate: result[1]
   };
 }
 
@@ -29,48 +91,63 @@ export default async function handler(req: GetQuoteRequest, res: NextApiResponse
       return res.status(400).json({ message: 'From and To tokens cannot be the same' });
     }
 
-    // Get token configurations
-    const fromTokenConfig = TOKEN_DEFINITIONS[fromTokenSymbol];
-    const toTokenConfig = TOKEN_DEFINITIONS[toTokenSymbol];
+    // Get pool configuration for these tokens
+    const poolConfig = getPoolConfigForTokens(fromTokenSymbol, toTokenSymbol);
 
-    if (!fromTokenConfig || !toTokenConfig) {
-      return res.status(400).json({ message: 'Invalid token symbol(s)' });
+    if (!poolConfig) {
+      return res.status(400).json({ message: `No pool found for token pair: ${fromTokenSymbol} → ${toTokenSymbol}` });
     }
 
     console.log(`[V4 Quoter] ${fromTokenSymbol} → ${toTokenSymbol}, amount: ${amountDecimalsStr}`);
     
-    // Calculate output amount based on the hardcoded price ratio
-    const fromAmount = parseFloat(amountDecimalsStr);
-    let toAmount = 0;
+    // Create Token instances
+    const fromToken = createTokenSDK(fromTokenSymbol, req.body.chainId);
+    const toToken = createTokenSDK(toTokenSymbol, req.body.chainId);
     
-    if (fromTokenSymbol === 'YUSDC' && toTokenSymbol === 'BTCRL') {
-      // 1 YUSD = ~0.000013 BTCRL (at 77000 BTCRL/USD)
-      toAmount = fromAmount / 77000;
-    } else if (fromTokenSymbol === 'BTCRL' && toTokenSymbol === 'YUSDC') {
-      // 1 BTCRL = ~77000 YUSD
-      toAmount = fromAmount * 77000;
-    } else {
-      return res.status(400).json({ message: `Unsupported token pair: ${fromTokenSymbol} → ${toTokenSymbol}` });
+    if (!fromToken || !toToken) {
+      return res.status(400).json({ message: 'Failed to create token instances' });
     }
     
-    // Add some small random variation to simulate price impact
-    const variation = 1 + (Math.random() * 0.02 - 0.01); // ±1% random variation
-    toAmount *= variation;
+    // Parse the input amount to smallest units
+    const amountInSmallestUnits = parseUnits(amountDecimalsStr, fromToken.decimals);
+    
+    // Get quote from V4Quoter
+    const { amountOut, gasEstimate } = await getV4QuoteExactInput(fromToken, toToken, amountInSmallestUnits, poolConfig);
+    
+    // Convert back to decimal string for response
+    const toAmountDecimals = Number(amountOut) / Math.pow(10, toToken.decimals);
     
     return res.status(200).json({
       success: true,
       fromAmount: amountDecimalsStr,
       fromToken: fromTokenSymbol,
-      toAmount: toAmount.toString(),
+      toAmount: toAmountDecimals.toString(),
       toToken: toTokenSymbol,
-      gasEstimate: '150000',
+      gasEstimate: gasEstimate.toString(),
       debug: true
     });
   } catch (error: any) {
     console.error('[V4 Quoter] Error:', error);
+    
+    // Handle specific V4Quoter errors
+    let errorMessage = 'Failed to get quote from V4Quoter';
+    if (error.message) {
+      if (error.message.includes('Pool does not exist') || error.message.includes('POOL_NOT_FOUND')) {
+        errorMessage = 'Pool not found for this token pair';
+      } else if (error.message.includes('Insufficient liquidity')) {
+        errorMessage = 'Insufficient liquidity for this swap amount';
+      } else if (error.message.includes('execution reverted')) {
+        errorMessage = 'Pool may not exist or be initialized for this token pair. Please check if the V4 pool exists with the specified parameters.';
+      } else if (error.message.includes('V4_QUOTER_ADDRESS_PLACEHOLDER')) {
+        errorMessage = 'V4Quoter contract address not configured';
+      } else {
+        errorMessage = error.message;
+      }
+    }
+    
     return res.status(500).json({
       success: false,
-      error: error.message || 'An unexpected error occurred'
+      error: errorMessage
     });
   }
 } 

--- a/pages/api/swap/get-quote.ts
+++ b/pages/api/swap/get-quote.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../lib/pools-config';
 import { V4QuoterAbi, EMPTY_BYTES } from '../../../lib/swap-constants';
 import { publicClient } from '../../../lib/viemClient';
+import { findBestRoute, SwapRoute, routeToString } from '../../../lib/routing-engine';
 
 interface GetQuoteRequest extends NextApiRequest {
   body: {
@@ -20,6 +21,77 @@ interface GetQuoteRequest extends NextApiRequest {
     chainId: number;
     debug?: boolean;
   };
+}
+
+// V4 PathKey type for multi-hop swaps
+// Must match the ABI: (address,uint24,int24,address,bytes)
+interface PathKey {
+  intermediateCurrency: Address;
+  fee: number;
+  tickSpacing: number;
+  hooks: Address;
+  hookData: `0x${string}`;
+}
+
+// Helper function to encode multi-hop path for V4
+function encodeMultihopPath(route: SwapRoute, chainId: number): PathKey[] {
+  const pathKeys: PathKey[] = [];
+  
+  console.log(`[encodeMultihopPath] Encoding route with ${route.pools.length} pools:`, {
+    path: route.path,
+    poolCount: route.pools.length
+  });
+  
+  for (let i = 0; i < route.pools.length; i++) {
+    const pool = route.pools[i];
+    
+    // For each hop, the intermediate currency is the "to" token of this hop
+    // (except for the last hop where it's the final destination)
+    let intermediateCurrency: Address;
+    let targetToken: string;
+    
+    if (i === route.pools.length - 1) {
+      // Last hop - intermediate currency is the final destination
+      targetToken = route.path[route.path.length - 1];
+      console.log(`[encodeMultihopPath] Last hop ${i}: target token = ${targetToken}`);
+    } else {
+      // Not the last hop - intermediate currency is the next token in the path
+      targetToken = route.path[i + 1];
+      console.log(`[encodeMultihopPath] Hop ${i}: target token = ${targetToken}`);
+    }
+    
+    const targetTokenSDK = createTokenSDK(targetToken as TokenSymbol, chainId);
+    
+    if (!targetTokenSDK) {
+      throw new Error(`Failed to create token SDK for ${targetToken} (hop ${i})`);
+    }
+    
+    if (!targetTokenSDK.address) {
+      throw new Error(`Token SDK for ${targetToken} has undefined address (hop ${i})`);
+    }
+    
+    intermediateCurrency = targetTokenSDK.address as Address;
+    console.log(`[encodeMultihopPath] Hop ${i}: intermediateCurrency = ${intermediateCurrency}`);
+    
+    if (!pool.hooks) {
+      throw new Error(`Pool at hop ${i} has undefined hooks address`);
+    }
+    
+    // Create fresh Address objects to ensure proper typing
+    const validatedIntermediateCurrency = getAddress(intermediateCurrency);
+    const validatedHooks = getAddress(pool.hooks);
+    
+    pathKeys.push({
+      intermediateCurrency: validatedIntermediateCurrency,
+      fee: pool.fee,
+      tickSpacing: pool.tickSpacing,
+      hooks: validatedHooks,
+      hookData: '0x' as `0x${string}`
+    });
+  }
+  
+  console.log(`[encodeMultihopPath] Successfully encoded ${pathKeys.length} path keys`);
+  return pathKeys;
 }
 
 // Helper function to create pool key and determine swap direction
@@ -36,8 +108,8 @@ function createPoolKeyAndDirection(fromToken: Token, toToken: Token, poolConfig:
   return { poolKey, zeroForOne };
 }
 
-// Helper function to call V4Quoter for exact input
-async function getV4QuoteExactInput(
+// Helper function to call V4Quoter for single-hop exact input
+async function getV4QuoteExactInputSingle(
   fromToken: Token,
   toToken: Token,
   amountInSmallestUnits: bigint,
@@ -60,17 +132,170 @@ async function getV4QuoteExactInput(
     EMPTY_BYTES
   ] as const;
 
-  const result = await publicClient.readContract({
-    address: getQuoterAddress(),
-    abi: V4QuoterAbi,
-    functionName: 'quoteExactInputSingle',
-    args: [quoteParams]
-  }) as [bigint, bigint]; // [amountOut, gasEstimate]
+  try {
+    const result = await publicClient.readContract({
+      address: getQuoterAddress(),
+      abi: V4QuoterAbi,
+      functionName: 'quoteExactInputSingle',
+      args: [quoteParams]
+    }) as [bigint, bigint]; // [amountOut, gasEstimate]
+    
+    return {
+      amountOut: result[0],
+      gasEstimate: result[1]
+    };
+  } catch (error: any) {
+    console.error(`[V4 Quoter] Single-hop quote error:`, {
+      message: error.message,
+      signature: error.signature,
+      cause: error.cause?.signature,
+      data: error.data,
+      shortMessage: error.shortMessage
+    });
+    
+    // Handle specific error signatures - check multiple possible locations
+    const errorSignature = error.signature || error.cause?.signature;
+    if (errorSignature === '0x6190b2b0' || error.message?.includes('0x6190b2b0')) {
+      throw new Error('Insufficient Liquidity');
+    }
+    
+    // Re-throw other errors
+    throw error;
+  }
+}
+
+// Helper function to call V4Quoter for multi-hop exact input
+async function getV4QuoteExactInputMultiHop(
+  fromToken: Token,
+  route: SwapRoute,
+  amountInSmallestUnits: bigint,
+  chainId: number
+): Promise<{ amountOut: bigint; gasEstimate: bigint }> {
   
-  return {
-    amountOut: result[0],
-    gasEstimate: result[1]
-  };
+  console.log(`[V4 Quoter] Multi-hop debug info:`, {
+    fromTokenSymbol: fromToken.symbol,
+    fromTokenAddress: fromToken.address,
+    fromTokenIsValid: !!fromToken.address,
+    routePath: route.path,
+    chainId
+  });
+  
+  if (!fromToken.address) {
+    throw new Error(`From token ${fromToken.symbol} has undefined address`);
+  }
+  
+  // Encode the multi-hop path
+  const pathKeys = encodeMultihopPath(route, chainId);
+  
+  console.log(`[V4 Quoter] Calling quoteExactInput for multi-hop:`, {
+    path: routeToString(route),
+    pathKeys: pathKeys.length,
+    exactAmount: amountInSmallestUnits.toString(),
+    fromTokenAddress: fromToken.address
+  });
+  
+  // Debug the pathKeys before making the contract call
+  console.log(`[V4 Quoter] Detailed pathKeys debug:`, pathKeys.map((pk, i) => ({
+    hop: i,
+    intermediateCurrency: pk.intermediateCurrency,
+    intermediateType: typeof pk.intermediateCurrency,
+    hooks: pk.hooks,
+    hooksType: typeof pk.hooks,
+    fee: pk.fee,
+    tickSpacing: pk.tickSpacing
+  })));
+
+  // Structure the parameters as QuoteExactParams struct
+  // ABI expects: (address,(address,uint24,int24,address,bytes)[],uint128)
+  const validatedCurrencyIn = getAddress(fromToken.address);
+  
+  // Convert PathKey objects to arrays as expected by the ABI
+  const pathTuples = pathKeys.map(pk => [
+    pk.intermediateCurrency,  // address
+    pk.fee,                   // uint24
+    pk.tickSpacing,           // int24
+    pk.hooks,                 // address
+    pk.hookData               // bytes
+  ] as const);
+  
+  const quoteParams = [
+    validatedCurrencyIn,      // address currencyIn
+    pathTuples,               // (address,uint24,int24,address,bytes)[] path
+    amountInSmallestUnits     // uint128 amountIn
+  ] as const;
+
+  const quoterAddress = getQuoterAddress();
+  
+  console.log(`[V4 Quoter] Full quoteParams debug:`, {
+    currencyIn: quoteParams[0],
+    currencyInType: typeof quoteParams[0],
+    pathLength: quoteParams[1].length,
+    amountIn: quoteParams[2].toString(),
+    quoterAddress: quoterAddress,
+    quoterAddressType: typeof quoterAddress
+  });
+  
+  // Debug the converted path tuples
+  console.log(`[V4 Quoter] Path tuples:`, pathTuples.map((tuple, i) => ({
+    hop: i,
+    intermediateCurrency: tuple[0],
+    fee: tuple[1],
+    tickSpacing: tuple[2],
+    hooks: tuple[3],
+    hookData: tuple[4]
+  })));
+
+  // Validate quoter address
+  if (!quoterAddress) {
+    throw new Error(`Quoter address is invalid: ${quoterAddress} (type: ${typeof quoterAddress})`);
+  }
+
+  // Validate all addresses before making the contract call
+  try {
+    getAddress(quoteParams[0]); // This will throw if invalid
+    pathTuples.forEach((tuple, i) => {
+      try {
+        getAddress(tuple[0]); // intermediateCurrency
+        getAddress(tuple[3]); // hooks
+      } catch (err) {
+        throw new Error(`Invalid address in pathTuple ${i}: intermediateCurrency=${tuple[0]}, hooks=${tuple[3]}, error=${err}`);
+      }
+    });
+  } catch (validationError: any) {
+    throw new Error(`Address validation failed: ${validationError.message}`);
+  }
+
+  // Note: Cannot JSON.stringify quoteParams due to BigInt values
+
+  try {
+    const result = await publicClient.readContract({
+      address: quoterAddress,
+      abi: V4QuoterAbi,
+      functionName: 'quoteExactInput',
+      args: [quoteParams] // Keep the array wrapper for the struct
+    }) as [bigint, bigint]; // [amountOut, gasEstimate]
+    
+    return {
+      amountOut: result[0],
+      gasEstimate: result[1]
+    };
+  } catch (error: any) {
+    console.error(`[V4 Quoter] Multi-hop quote failed:`, {
+      message: error.message,
+      signature: error.signature,
+      cause: error.cause?.signature,
+      data: error.data,
+      shortMessage: error.shortMessage
+    });
+    
+    // Handle specific error signatures - check multiple possible locations
+    const errorSignature = error.signature || error.cause?.signature;
+    if (errorSignature === '0x6190b2b0' || error.message?.includes('0x6190b2b0')) {
+      throw new Error('Insufficient Liquidity');
+    }
+    
+    throw new Error(`Multi-hop quote failed: ${error.message || 'Unknown error'}`);
+  }
 }
 
 export default async function handler(req: GetQuoteRequest, res: NextApiResponse) {
@@ -91,18 +316,37 @@ export default async function handler(req: GetQuoteRequest, res: NextApiResponse
       return res.status(400).json({ message: 'From and To tokens cannot be the same' });
     }
 
-    // Get pool configuration for these tokens
-    const poolConfig = getPoolConfigForTokens(fromTokenSymbol, toTokenSymbol);
-
-    if (!poolConfig) {
-      return res.status(400).json({ message: `No pool found for token pair: ${fromTokenSymbol} → ${toTokenSymbol}` });
-    }
-
-    console.log(`[V4 Quoter] ${fromTokenSymbol} → ${toTokenSymbol}, amount: ${amountDecimalsStr}`);
+    console.log(`[V4 Quoter] ${fromTokenSymbol} → ${toTokenSymbol}, amount: ${amountDecimalsStr}, chainId: ${req.body.chainId}`);
     
     // Create Token instances
     const fromToken = createTokenSDK(fromTokenSymbol, req.body.chainId);
     const toToken = createTokenSDK(toTokenSymbol, req.body.chainId);
+    
+    console.log(`[V4 Quoter] Token creation debug:`, {
+      fromTokenSymbol,
+      fromTokenValid: !!fromToken,
+      fromTokenAddress: fromToken?.address,
+      fromTokenAddressType: typeof fromToken?.address,
+      toTokenSymbol,
+      toTokenValid: !!toToken,
+      toTokenAddress: toToken?.address,
+      toTokenAddressType: typeof toToken?.address
+    });
+    
+    // Additional validation - check for undefined addresses
+    if (fromToken?.address === undefined || fromToken?.address === 'undefined') {
+      return res.status(400).json({ 
+        message: `From token ${fromTokenSymbol} has undefined address`,
+        debug: { fromTokenAddress: fromToken?.address, type: typeof fromToken?.address }
+      });
+    }
+    
+    if (toToken?.address === undefined || toToken?.address === 'undefined') {
+      return res.status(400).json({ 
+        message: `To token ${toTokenSymbol} has undefined address`,
+        debug: { toTokenAddress: toToken?.address, type: typeof toToken?.address }
+      });
+    }
     
     if (!fromToken || !toToken) {
       return res.status(400).json({ message: 'Failed to create token instances' });
@@ -111,8 +355,39 @@ export default async function handler(req: GetQuoteRequest, res: NextApiResponse
     // Parse the input amount to smallest units
     const amountInSmallestUnits = parseUnits(amountDecimalsStr, fromToken.decimals);
     
-    // Get quote from V4Quoter
-    const { amountOut, gasEstimate } = await getV4QuoteExactInput(fromToken, toToken, amountInSmallestUnits, poolConfig);
+    // Find the best route using the routing engine
+    const routeResult = findBestRoute(fromTokenSymbol, toTokenSymbol);
+    
+    if (!routeResult.bestRoute) {
+      return res.status(400).json({ 
+        message: `No route found for token pair: ${fromTokenSymbol} → ${toTokenSymbol}`,
+        error: 'No available pools to complete this swap'
+      });
+    }
+
+    const route = routeResult.bestRoute;
+    console.log(`[V4 Quoter] Using route: ${routeToString(route)}`);
+    
+    let amountOut: bigint;
+    let gasEstimate: bigint;
+    
+    if (route.isDirectRoute) {
+      // Single-hop swap using existing logic
+      const poolConfig = getPoolConfigForTokens(fromTokenSymbol, toTokenSymbol);
+      
+      if (!poolConfig) {
+        return res.status(400).json({ message: `Pool configuration not found for direct route: ${fromTokenSymbol} → ${toTokenSymbol}` });
+      }
+      
+      const result = await getV4QuoteExactInputSingle(fromToken, toToken, amountInSmallestUnits, poolConfig);
+      amountOut = result.amountOut;
+      gasEstimate = result.gasEstimate;
+    } else {
+      // Multi-hop swap using new logic
+      const result = await getV4QuoteExactInputMultiHop(fromToken, route, amountInSmallestUnits, req.body.chainId);
+      amountOut = result.amountOut;
+      gasEstimate = result.gasEstimate;
+    }
     
     // Convert back to decimal string for response
     const toAmountDecimals = Number(amountOut) / Math.pow(10, toToken.decimals);
@@ -124,6 +399,12 @@ export default async function handler(req: GetQuoteRequest, res: NextApiResponse
       toAmount: toAmountDecimals.toString(),
       toToken: toTokenSymbol,
       gasEstimate: gasEstimate.toString(),
+      route: {
+        path: route.path,
+        hops: route.hops,
+        isDirectRoute: route.isDirectRoute,
+        pools: route.pools.map(pool => pool.poolName)
+      },
       debug: true
     });
   } catch (error: any) {
@@ -135,11 +416,13 @@ export default async function handler(req: GetQuoteRequest, res: NextApiResponse
       if (error.message.includes('Pool does not exist') || error.message.includes('POOL_NOT_FOUND')) {
         errorMessage = 'Pool not found for this token pair';
       } else if (error.message.includes('Insufficient liquidity')) {
-        errorMessage = 'Insufficient liquidity for this swap amount';
+        errorMessage = error.message; // Use the specific liquidity error message
       } else if (error.message.includes('execution reverted')) {
         errorMessage = 'Pool may not exist or be initialized for this token pair. Please check if the V4 pool exists with the specified parameters.';
       } else if (error.message.includes('V4_QUOTER_ADDRESS_PLACEHOLDER')) {
         errorMessage = 'V4Quoter contract address not configured';
+      } else if (error.message.includes('Multi-hop quote failed')) {
+        errorMessage = error.message;
       } else {
         errorMessage = error.message;
       }

--- a/public/ETH.svg
+++ b/public/ETH.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="32" fill="#3c3c3d"/>
+  <text x="32" y="38" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="14" font-weight="bold">ETH</text>
+</svg> 

--- a/public/aETH.svg
+++ b/public/aETH.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="32" fill="#627eea"/>
+  <text x="32" y="38" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="12" font-weight="bold">aETH</text>
+</svg> 

--- a/public/mUSDT.svg
+++ b/public/mUSDT.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="32" fill="#26a69a"/>
+  <text x="32" y="38" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="11" font-weight="bold">mUSDT</text>
+</svg> 


### PR DESCRIPTION
## Summary
- Added Upstash Redis caching layer (`lib/redis.ts`, `lib/cache-keys.ts`)
- Cached `get-pools-batch` endpoint (5min fresh, 15min max TTL)
- Created `pool-metrics` endpoint with caching (1hr fresh, 2hr max TTL)
- Stale-while-revalidate pattern for fast responses

## Test plan
- [ ] Verify Redis keys appear in Upstash dashboard after page load
- [ ] Confirm second page load is faster (cache hit)
- [ ] Check cache invalidation after TTL expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes pool/token config, adds Redis-backed caching and new metrics APIs, and overhauls swap/liquidity flows with multi-hop routing and V4 Quoter integration plus UI updates.
> 
> - **Config/Core**:
>   - Centralize pools/tokens/contracts in `config/pools.json` with helpers in `lib/pools-config` (replaces scattered constants; exposes IDs, tickSpacing, hooks).
>   - New utilities: `lib/format`, enhanced `lib/price-service` (adds ETH), routing engine (`lib/routing-engine`).
> - **Caching/Infra**:
>   - Add Upstash Redis wrapper `lib/redis` and keys/TTLs in `lib/cache-keys`; adopt stale-while-revalidate.
> - **APIs**:
>   - New: `api/liquidity/get-pools-batch` (TVL/volume/fees + on-chain fee), `api/liquidity/pool-metrics`, `api/liquidity/get-pool-params`, `api/liquidity/initialize-pool`.
>   - Overhaul existing endpoints (`get-quote`, `build-tx`, `get-pool-state`, `calculate-liquidity-parameters`, `get-positions`, `get-rolling-volume-fees`, `get-pool-tvl`, `get-dynamic-fee`) to use pools config, subgraph IDs, on-chain checks, multi-hop routing, and V4 Quoter.
> - **Swap**:
>   - Integrate V4 Quoter and multi-hop routing; show route details/fees; add `TokenSelector`; refactor UI logic.
> - **Liquidity UI**:
>   - Revamp pages: use config-driven pools, batch/APR hooks (`components/data/hooks`), tickSpacing-aware visuals, improved charts, and position filtering by subgraph ID.
>   - Update add/increase/decrease/burn flows for config tokens, Permit2 handling, and native ETH support.
> - **Assets/UX**:
>   - Add token icons (`ETH.svg`, `aETH.svg`, `mUSDT.svg`); minor AccountStatus tweak with “Coming Soon” overlay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb1a1328ec0b696733d2dd7450282829f0b2d7d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->